### PR TITLE
TS.Net.Engine: Multidevice commandline arguments

### DIFF
--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+﻿using System.CommandLine;
 using System.Diagnostics;
 using TS.NET;
 using TS.NET.Engine;
@@ -17,102 +16,144 @@ using (Process p = Process.GetCurrentProcess())
     p.PriorityClass = ProcessPriorityClass.High;
 
 #if DEBUG
-ThunderscopeSettings settings = ThunderscopeSettings.Default();
-var serializer = new YamlDotNet.Serialization.SerializerBuilder()
-    .WithNamingConvention(YamlDotNet.Serialization.NamingConventions.PascalCaseNamingConvention.Instance)
-    .Build();
-string yaml = serializer.Serialize(settings);
-File.WriteAllText("thunderscope (defaults).yaml", yaml);
+		ThunderscopeSettings settings = ThunderscopeSettings.Default();
+		var serializer = new YamlDotNet.Serialization.SerializerBuilder()
+			.WithNamingConvention(
+				YamlDotNet.Serialization.NamingConventions.PascalCaseNamingConvention.Instance
+			)
+			.Build();
+		string yaml = serializer.Serialize(settings);
+		File.WriteAllText("thunderscope (defaults).yaml", yaml);
 #endif
 
-IConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
-    .AddJsonFile("appsettings.json");
-var configuration = configurationBuilder.Build();
-var thunderscopeSettings = ThunderscopeSettings.FromYamlFile("thunderscope.yaml");
+		IConfigurationBuilder configurationBuilder = new ConfigurationBuilder().AddJsonFile(
+			"appsettings.json"
+		);
+		var configuration = configurationBuilder.Build();
+		var thunderscopeSettings = ThunderscopeSettings.FromYamlFile("thunderscope.yaml");
 
-var loggerFactory = LoggerFactory.Create(configure =>
-{
-    configure
-        .ClearProviders()
-        .AddConfiguration(configuration.GetSection("Logging"))
-        .AddFile(configuration.GetSection("Logging"))
-        .AddSimpleConsole(options => { options.SingleLine = true; options.TimestampFormat = "HH:mm:ss "; });
-});
+		var loggerFactory = LoggerFactory.Create(configure =>
+		{
+			configure
+				.ClearProviders()
+				.AddConfiguration(configuration.GetSection("Logging"))
+				.AddFile(configuration.GetSection("Logging"))
+				.AddSimpleConsole(options =>
+				{
+					options.SingleLine = true;
+					options.TimestampFormat = "HH:mm:ss ";
+				});
+		});
 
-// Instantiate dataflow channels
-const int bufferLength = 120;       // 120 = about 1 seconds worth of samples at 1GSPS (each ThunderscopeMemory is 8388608 bytes), 120x = 1006632960
+		// Instantiate dataflow channels
+		const int bufferLength = 120; // 120 = about 1 seconds worth of samples at 1GSPS (each ThunderscopeMemory is 8388608 bytes), 120x = 1006632960
 
-ThunderscopeMemoryRegion memoryRegion = new(bufferLength);
-BlockingChannel<ThunderscopeMemory> inputChannel = new(bufferLength);
-for (uint i = 0; i < bufferLength; i++)
-    inputChannel.Writer.Write(memoryRegion.GetSegment(i));
-BlockingChannel<InputDataDto> processChannel = new();
-BlockingChannel<HardwareRequestDto> hardwareRequestChannel = new();
-BlockingChannel<HardwareResponseDto> hardwareResponseChannel = new();
-BlockingChannel<ProcessingRequestDto> processingRequestChannel = new();
-BlockingChannel<ProcessingResponseDto> processingResponseChannel = new();
+		ThunderscopeMemoryRegion memoryRegion = new(bufferLength);
+		BlockingChannel<ThunderscopeMemory> inputChannel = new(bufferLength);
+		for (uint i = 0; i < bufferLength; i++)
+			inputChannel.Writer.Write(memoryRegion.GetSegment(i));
+		BlockingChannel<InputDataDto> processChannel = new();
+		BlockingChannel<HardwareRequestDto> hardwareRequestChannel = new();
+		BlockingChannel<HardwareResponseDto> hardwareResponseChannel = new();
+		BlockingChannel<ProcessingRequestDto> processingRequestChannel = new();
+		BlockingChannel<ProcessingResponseDto> processingResponseChannel = new();
 
-Thread.Sleep(1000);
+		Thread.Sleep(1000);
 
-IThunderscope thunderscope;
-switch (thunderscopeSettings.Driver.ToLower())
-{
-    case "simulator":
-        {
-            var ts = new TS.NET.Driver.Simulator.Thunderscope();
-            thunderscope = ts;
-            break;
-        }
-    case "xdma":
-        {
-            // Find thunderscope
-            var devices = TS.NET.Driver.XMDA.Thunderscope.IterateDevices();
-            if (devices.Count == 0)
-                throw new Exception("No thunderscopes found");
-            var ts = new TS.NET.Driver.XMDA.Thunderscope();
-            ts.Open(devices[0], thunderscopeSettings.Calibration.ToDriver());
-            thunderscope = ts;
-            break;
-        }
-    default:
-        throw new ArgumentException($"{thunderscopeSettings.Driver} driver not supported");
+		IThunderscope thunderscope;
+		switch (thunderscopeSettings.Driver.ToLower())
+		{
+			case "simulator":
+			{
+				var ts = new TS.NET.Driver.Simulator.Thunderscope();
+				thunderscope = ts;
+				break;
+			}
+			case "xdma":
+			{
+				// Find thunderscope
+				var devices = TS.NET.Driver.XMDA.Thunderscope.IterateDevices();
+				if (devices.Count == 0)
+					throw new Exception("No thunderscopes found");
+				if (indexThunderscope > devices.Count-1) 
+					throw new Exception("Invalid index thunderscope " + indexThunderscope + ". Only " + devices.Count + " Thunderscopes connected.");
+				var ts = new TS.NET.Driver.XMDA.Thunderscope();
+				ts.Open(devices[indexThunderscope], thunderscopeSettings.Calibration.ToDriver(), hwRevision);
+				thunderscope = ts;
+				break;
+			}
+			default:
+				throw new ArgumentException($"{thunderscopeSettings.Driver} driver not supported");
+		}
+
+		// Start threads
+		SemaphoreSlim startSemaphore = new(1);
+
+		startSemaphore.Wait();
+		ProcessingThread processingThread =
+			new(
+				loggerFactory,
+				thunderscopeSettings,
+				processChannel.Reader,
+				inputChannel.Writer,
+				processingRequestChannel.Reader,
+				processingResponseChannel.Writer
+			);
+		processingThread.Start(startSemaphore);
+
+		startSemaphore.Wait();
+		HardwareThread hardwareThread =
+			new(
+				loggerFactory,
+				thunderscopeSettings,
+				thunderscope,
+				inputChannel.Reader,
+				processChannel.Writer,
+				hardwareRequestChannel.Reader,
+				hardwareResponseChannel.Writer
+			);
+		hardwareThread.Start(startSemaphore);
+
+		startSemaphore.Wait();
+		WaveformServer? waveformServer = null;
+		if (thunderscopeSettings.Twinlan)
+		{
+			waveformServer = new(
+				loggerFactory,
+				thunderscopeSettings,
+				System.Net.IPAddress.Any,
+				dataPort
+			);
+			waveformServer.Start();
+		}
+
+		ScpiServer scpiServer =
+			new(
+				loggerFactory,
+				System.Net.IPAddress.Any,
+				controlPort,
+				hardwareRequestChannel.Writer,
+				hardwareResponseChannel.Reader,
+				processingRequestChannel.Writer,
+				processingResponseChannel.Reader
+			);
+		scpiServer.Start();
+
+		bool loop = true;
+		while (loop)
+		{
+			var key = Console.ReadKey();
+			switch (key.Key)
+			{
+				case ConsoleKey.Escape:
+					loop = false;
+					break;
+			}
+		}
+
+		scpiServer.Stop();
+		waveformServer?.Stop();
+		hardwareThread.Stop();
+		processingThread.Stop();
+	}
 }
-
-// Start threads
-SemaphoreSlim startSemaphore = new(1);
-
-startSemaphore.Wait();
-ProcessingThread processingThread = new(loggerFactory, thunderscopeSettings, processChannel.Reader, inputChannel.Writer, processingRequestChannel.Reader, processingResponseChannel.Writer);
-processingThread.Start(startSemaphore);
-
-startSemaphore.Wait();
-HardwareThread hardwareThread = new(loggerFactory, thunderscopeSettings, thunderscope, inputChannel.Reader, processChannel.Writer, hardwareRequestChannel.Reader, hardwareResponseChannel.Writer);
-hardwareThread.Start(startSemaphore);
-
-startSemaphore.Wait();
-WaveformServer? waveformServer = null;
-if (thunderscopeSettings.Twinlan)
-{
-    waveformServer = new(loggerFactory, thunderscopeSettings, System.Net.IPAddress.Any, 5026);
-    waveformServer.Start();
-}
-
-ScpiServer scpiServer = new(loggerFactory, System.Net.IPAddress.Any, 5025, hardwareRequestChannel.Writer, hardwareResponseChannel.Reader, processingRequestChannel.Writer, processingResponseChannel.Reader);
-scpiServer.Start();
-
-bool loop = true;
-while (loop)
-{
-    var key = Console.ReadKey();
-    switch (key.Key)
-    {
-        case ConsoleKey.Escape:
-            loop = false;
-            break;
-    }
-}
-
-scpiServer.Stop();
-waveformServer?.Stop();
-hardwareThread.Stop();
-processingThread.Stop();

--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -1,5 +1,9 @@
 ﻿using System.CommandLine;
 using System.Diagnostics;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using TS.NET;
 using TS.NET.Engine;
 
@@ -117,6 +121,7 @@ class Program
 			{
 				var ts = new TS.NET.Driver.Simulator.Thunderscope();
 				thunderscope = ts;
+				
 				break;
 			}
 			case "xdma":
@@ -147,7 +152,8 @@ class Program
 				processChannel.Reader,
 				inputChannel.Writer,
 				processingRequestChannel.Reader,
-				processingResponseChannel.Writer
+				processingResponseChannel.Writer,
+				indexThunderscope
 			);
 		processingThread.Start(startSemaphore);
 
@@ -172,7 +178,8 @@ class Program
 				loggerFactory,
 				thunderscopeSettings,
 				System.Net.IPAddress.Any,
-				dataPort
+				dataPort,
+				indexThunderscope
 			);
 			waveformServer.Start();
 		}

--- a/source/TS.NET.Engine/TS.NET.Engine.csproj
+++ b/source/TS.NET.Engine/TS.NET.Engine.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="NetCoreServer" Version="7.0.0" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.6" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="15.1.2" />
     <PackageReference Include="YamlDotNet" Version="15.1.4" />
   </ItemGroup>

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -3,217 +3,217 @@ using System.Diagnostics;
 
 namespace TS.NET.Engine
 {
-    // The job of this task is to read from the thunderscope as fast as possible with minimal jitter
-    internal class HardwareThread
-    {
-        private readonly ILogger logger;
-        private readonly IThunderscope thunderscope;
-        private readonly ThunderscopeSettings settings;
-        private readonly BlockingChannelReader<ThunderscopeMemory> inputChannel;
-        private readonly BlockingChannelWriter<InputDataDto> processChannel;
-        private readonly BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel;
-        private readonly BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel;
+	// The job of this task is to read from the thunderscope as fast as possible with minimal jitter
+	internal class HardwareThread
+	{
+		private readonly ILogger logger;
+		private readonly IThunderscope thunderscope;
+		private readonly ThunderscopeSettings settings;
+		private readonly BlockingChannelReader<ThunderscopeMemory> inputChannel;
+		private readonly BlockingChannelWriter<InputDataDto> processChannel;
+		private readonly BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel;
+		private readonly BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel;
 
-        private CancellationTokenSource? cancelTokenSource;
-        private Task? taskLoop;
+		private CancellationTokenSource? cancelTokenSource;
+		private Task? taskLoop;
 
-        public HardwareThread(ILoggerFactory loggerFactory,
-            ThunderscopeSettings settings,
-            IThunderscope thunderscope,
-            BlockingChannelReader<ThunderscopeMemory> inputChannel,
-            BlockingChannelWriter<InputDataDto> processChannel,
-            BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel,
-            BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel)
-        {
-            logger = loggerFactory.CreateLogger(nameof(HardwareThread));
-            this.settings = settings;
-            this.thunderscope = thunderscope;
-            this.inputChannel = inputChannel;
-            this.processChannel = processChannel;
-            this.hardwareRequestChannel = hardwareRequestChannel;
-            this.hardwareResponseChannel = hardwareResponseChannel;
-        }
+		public HardwareThread(ILoggerFactory loggerFactory,
+			ThunderscopeSettings settings,
+			IThunderscope thunderscope,
+			BlockingChannelReader<ThunderscopeMemory> inputChannel,
+			BlockingChannelWriter<InputDataDto> processChannel,
+			BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel,
+			BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel)
+		{
+			logger = loggerFactory.CreateLogger(nameof(HardwareThread));
+			this.settings = settings;
+			this.thunderscope = thunderscope;
+			this.inputChannel = inputChannel;
+			this.processChannel = processChannel;
+			this.hardwareRequestChannel = hardwareRequestChannel;
+			this.hardwareResponseChannel = hardwareResponseChannel;
+		}
 
-        public void Start(SemaphoreSlim startSemaphore)
-        {
-            cancelTokenSource = new CancellationTokenSource();
-            taskLoop = Task.Factory.StartNew(() => Loop(logger, thunderscope, settings, inputChannel, processChannel, hardwareRequestChannel, hardwareResponseChannel, startSemaphore, cancelTokenSource.Token), TaskCreationOptions.LongRunning);
-        }
+		public void Start(SemaphoreSlim startSemaphore)
+		{
+			cancelTokenSource = new CancellationTokenSource();
+			taskLoop = Task.Factory.StartNew(() => Loop(logger, thunderscope, settings, inputChannel, processChannel, hardwareRequestChannel, hardwareResponseChannel, startSemaphore, cancelTokenSource.Token), TaskCreationOptions.LongRunning);
+		}
 
-        public void Stop()
-        {
-            cancelTokenSource?.Cancel();
-            taskLoop?.Wait();
-        }
+		public void Stop()
+		{
+			cancelTokenSource?.Cancel();
+			taskLoop?.Wait();
+		}
 
-        private static void Loop(
-            ILogger logger,
-            IThunderscope thunderscope,
-            ThunderscopeSettings settings,
-            BlockingChannelReader<ThunderscopeMemory> inputChannel,
-            BlockingChannelWriter<InputDataDto> processChannel,
-            BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel,
-            BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel,
-            SemaphoreSlim startSemaphore,
-            CancellationToken cancelToken)
-        {
-            Thread.CurrentThread.Name = nameof(HardwareThread);
-            //Thread.CurrentThread.Priority = ThreadPriority.Highest;
-            if (settings.HardwareThreadProcessorAffinity > -1 && OperatingSystem.IsWindows())
-            {
-                Thread.BeginThreadAffinity();
-                OsThread.SetThreadAffinity(settings.HardwareThreadProcessorAffinity);
-                logger.LogDebug($"{nameof(HardwareThread)} thread processor affinity set to {settings.HardwareThreadProcessorAffinity}");
-            }
-            
-            try
-            {               
-                thunderscope.Start();
-                logger.LogInformation("Started");
-                startSemaphore.Release();
+		private static void Loop(
+			ILogger logger,
+			IThunderscope thunderscope,
+			ThunderscopeSettings settings,
+			BlockingChannelReader<ThunderscopeMemory> inputChannel,
+			BlockingChannelWriter<InputDataDto> processChannel,
+			BlockingChannelReader<HardwareRequestDto> hardwareRequestChannel,
+			BlockingChannelWriter<HardwareResponseDto> hardwareResponseChannel,
+			SemaphoreSlim startSemaphore,
+			CancellationToken cancelToken)
+		{
+			Thread.CurrentThread.Name = nameof(HardwareThread)+ new Random().Next();
+			//Thread.CurrentThread.Priority = ThreadPriority.Highest;
+			if (settings.HardwareThreadProcessorAffinity > -1 && OperatingSystem.IsWindows())
+			{
+				Thread.BeginThreadAffinity();
+				OsThread.SetThreadAffinity(settings.HardwareThreadProcessorAffinity);
+				logger.LogDebug($"{nameof(HardwareThread)} thread processor affinity set to {settings.HardwareThreadProcessorAffinity}");
+			}
+			
+			try
+			{               
+				thunderscope.Start();
+				logger.LogInformation("Started");
+				startSemaphore.Release();
 
-                logger.LogDebug("Waiting for first block of data...");
+				logger.LogDebug("Waiting for first block of data...");
 
-                Stopwatch periodicUpdateTimer = Stopwatch.StartNew();
-                uint periodicEnqueueCount = 0;
-                uint enqueueCounter = 0;
+				Stopwatch periodicUpdateTimer = Stopwatch.StartNew();
+				uint periodicEnqueueCount = 0;
+				uint enqueueCounter = 0;
 
-                while (true)
-                {
-                    cancelToken.ThrowIfCancellationRequested();
+				while (true)
+				{
+					cancelToken.ThrowIfCancellationRequested();
 
-                    // Check for configuration requests
-                    if (hardwareRequestChannel.PeekAvailable() != 0)
-                    {
-                        logger.LogDebug("Stop acquisition and process commands...");
-                        thunderscope.Stop();
+					// Check for configuration requests
+					if (hardwareRequestChannel.PeekAvailable() != 0)
+					{
+						logger.LogDebug("Stop acquisition and process commands...");
+						thunderscope.Stop();
 
-                        while (hardwareRequestChannel.TryRead(out var request))
-                        {
-                            // Do configuration update, pausing acquisition if necessary
-                            switch (request)
-                            {
-                                case HardwareStartRequest hardwareStartRequest:
-                                    logger.LogDebug("Start request (ignore)");
-                                    break;
-                                case HardwareStopRequest hardwareStopRequest:
-                                    logger.LogDebug("Stop request (ignore)");
-                                    break;
-                                case HardwareConfigureChannelDto hardwareConfigureChannelDto:
-                                    var channelIndex = ((HardwareConfigureChannelDto)request).Channel;
-                                    ThunderscopeChannel channel = thunderscope.GetChannel(channelIndex);
-                                    switch (request)
-                                    {
-                                        case HardwareSetVoltOffsetRequest hardwareSetOffsetRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetVoltOffsetRequest)} (channel: {channelIndex}, offset: {hardwareSetOffsetRequest.VoltOffset})");
-                                            channel.VoltOffset = hardwareSetOffsetRequest.VoltOffset;
-                                            break;
-                                        case HardwareSetVoltFullScaleRequest hardwareSetVdivRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetVoltFullScaleRequest)} (channel: {channelIndex}, scale: {hardwareSetVdivRequest.VoltFullScale})");
-                                            channel.VoltFullScale = hardwareSetVdivRequest.VoltFullScale;
-                                            break;
-                                        case HardwareSetBandwidthRequest hardwareSetBandwidthRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetBandwidthRequest)} (channel: {channelIndex}, bandwidth: {hardwareSetBandwidthRequest.Bandwidth})");
-                                            channel.Bandwidth = hardwareSetBandwidthRequest.Bandwidth;
-                                            break;
-                                        case HardwareSetCouplingRequest hardwareSetCouplingRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetCouplingRequest)} (channel: {channelIndex}, coupling: {hardwareSetCouplingRequest.Coupling})");
-                                            channel.Coupling = hardwareSetCouplingRequest.Coupling;
-                                            break;
-                                        case HardwareSetEnabledRequest hardwareSetEnabledRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetEnabledRequest)} (channel: {channelIndex}, enabled: {hardwareSetEnabledRequest.Enabled})");
-                                            thunderscope.SetChannelEnable(channelIndex, hardwareSetEnabledRequest.Enabled);
-                                            break;
-                                        case HardwareSetTerminationRequest hardwareSetTerminationRequest:
-                                            logger.LogDebug($"{nameof(HardwareSetTerminationRequest)} (channel: {channelIndex}, termination: {hardwareSetTerminationRequest.Termination})");
-                                            channel.Termination = hardwareSetTerminationRequest.Termination;
-                                            break;
-                                        default:
-                                            logger.LogWarning($"Unknown {nameof(HardwareConfigureChannelDto)}: {request}");
-                                            break;
-                                    }
-                                    thunderscope.SetChannel(channelIndex, channel);
-                                    break;
-                                default:
-                                    logger.LogWarning($"Unknown {nameof(HardwareRequestDto)}: {request}");
-                                    break;
-                            }
-                            if (hardwareRequestChannel.PeekAvailable() == 0)
-                                Thread.Sleep(150);
-                        }
+						while (hardwareRequestChannel.TryRead(out var request))
+						{
+							// Do configuration update, pausing acquisition if necessary
+							switch (request)
+							{
+								case HardwareStartRequest hardwareStartRequest:
+									logger.LogDebug("Start request (ignore)");
+									break;
+								case HardwareStopRequest hardwareStopRequest:
+									logger.LogDebug("Stop request (ignore)");
+									break;
+								case HardwareConfigureChannelDto hardwareConfigureChannelDto:
+									var channelIndex = ((HardwareConfigureChannelDto)request).Channel;
+									ThunderscopeChannel channel = thunderscope.GetChannel(channelIndex);
+									switch (request)
+									{
+										case HardwareSetVoltOffsetRequest hardwareSetOffsetRequest:
+											logger.LogDebug($"{nameof(HardwareSetVoltOffsetRequest)} (channel: {channelIndex}, offset: {hardwareSetOffsetRequest.VoltOffset})");
+											channel.VoltOffset = hardwareSetOffsetRequest.VoltOffset;
+											break;
+										case HardwareSetVoltFullScaleRequest hardwareSetVdivRequest:
+											logger.LogDebug($"{nameof(HardwareSetVoltFullScaleRequest)} (channel: {channelIndex}, scale: {hardwareSetVdivRequest.VoltFullScale})");
+											channel.VoltFullScale = hardwareSetVdivRequest.VoltFullScale;
+											break;
+										case HardwareSetBandwidthRequest hardwareSetBandwidthRequest:
+											logger.LogDebug($"{nameof(HardwareSetBandwidthRequest)} (channel: {channelIndex}, bandwidth: {hardwareSetBandwidthRequest.Bandwidth})");
+											channel.Bandwidth = hardwareSetBandwidthRequest.Bandwidth;
+											break;
+										case HardwareSetCouplingRequest hardwareSetCouplingRequest:
+											logger.LogDebug($"{nameof(HardwareSetCouplingRequest)} (channel: {channelIndex}, coupling: {hardwareSetCouplingRequest.Coupling})");
+											channel.Coupling = hardwareSetCouplingRequest.Coupling;
+											break;
+										case HardwareSetEnabledRequest hardwareSetEnabledRequest:
+											logger.LogDebug($"{nameof(HardwareSetEnabledRequest)} (channel: {channelIndex}, enabled: {hardwareSetEnabledRequest.Enabled})");
+											thunderscope.SetChannelEnable(channelIndex, hardwareSetEnabledRequest.Enabled);
+											break;
+										case HardwareSetTerminationRequest hardwareSetTerminationRequest:
+											logger.LogDebug($"{nameof(HardwareSetTerminationRequest)} (channel: {channelIndex}, termination: {hardwareSetTerminationRequest.Termination})");
+											channel.Termination = hardwareSetTerminationRequest.Termination;
+											break;
+										default:
+											logger.LogWarning($"Unknown {nameof(HardwareConfigureChannelDto)}: {request}");
+											break;
+									}
+									thunderscope.SetChannel(channelIndex, channel);
+									break;
+								default:
+									logger.LogWarning($"Unknown {nameof(HardwareRequestDto)}: {request}");
+									break;
+							}
+							if (hardwareRequestChannel.PeekAvailable() == 0)
+								Thread.Sleep(150);
+						}
 
-                        logger.LogDebug("Start again");
-                        thunderscope.Start();
-                    }
+						logger.LogDebug("Start again");
+						thunderscope.Start();
+					}
 
-                    //logger.LogDebug($"Requesting memory block {enqueueCounter}");
-                    var memory = inputChannel.Read(cancelToken);
-                    //logger.LogDebug($"Memory block {enqueueCounter}");
-                    while (true)
-                    {
-                        try
-                        {
-                            thunderscope.Read(memory, cancelToken);
-                            if (enqueueCounter == 0)
-                                logger.LogDebug("First block of data received");
-                            //logger.LogDebug($"Acquisition block {enqueueCounter}");
-                            break;
-                        }
-                        catch (ThunderscopeMemoryOutOfMemoryException)
-                        {
-                            logger.LogWarning("Scope ran out of memory - reset buffer pointers and continue");
-                            ((Driver.XMDA.Thunderscope)thunderscope).ResetBuffer();
-                            continue;
-                        }
-                        catch (ThunderscopeFifoOverflowException)
-                        {
-                            logger.LogWarning("Scope had FIFO overflow - ignore and continue");
-                            continue;
-                        }
-                        catch (ThunderscopeNotRunningException)
-                        {
-                            // logger.LogWarning("Tried to read from stopped scope");
-                            continue;
-                        }
-                        catch (Exception ex)
-                        {
-                            if (ex.Message == "ReadFile - failed (1359)")
-                            {
-                                logger.LogError(ex, $"{nameof(HardwareThread)} error");
-                                continue;
-                            }
-                            throw;
-                        }
-                    }
+					//logger.LogDebug($"Requesting memory block {enqueueCounter}");
+					var memory = inputChannel.Read(cancelToken);
+					//logger.LogDebug($"Memory block {enqueueCounter}");
+					while (true)
+					{
+						try
+						{
+							thunderscope.Read(memory, cancelToken);
+							if (enqueueCounter == 0)
+								logger.LogDebug("First block of data received");
+							//logger.LogDebug($"Acquisition block {enqueueCounter}");
+							break;
+						}
+						catch (ThunderscopeMemoryOutOfMemoryException)
+						{
+							logger.LogWarning("Scope ran out of memory - reset buffer pointers and continue");
+							((Driver.XMDA.Thunderscope)thunderscope).ResetBuffer();
+							continue;
+						}
+						catch (ThunderscopeFifoOverflowException)
+						{
+							logger.LogWarning("Scope had FIFO overflow - ignore and continue");
+							continue;
+						}
+						catch (ThunderscopeNotRunningException)
+						{
+							// logger.LogWarning("Tried to read from stopped scope");
+							continue;
+						}
+						catch (Exception ex)
+						{
+							if (ex.Message == "ReadFile - failed (1359)")
+							{
+								logger.LogError(ex, $"{nameof(HardwareThread)} error");
+								continue;
+							}
+							throw;
+						}
+					}
 
-                    periodicEnqueueCount++;
-                    enqueueCounter++;
+					periodicEnqueueCount++;
+					enqueueCounter++;
 
-                    processChannel.Write(new InputDataDto(thunderscope.GetConfiguration(), memory), cancelToken);
+					processChannel.Write(new InputDataDto(thunderscope.GetConfiguration(), memory), cancelToken);
 
-                    if (periodicUpdateTimer.ElapsedMilliseconds >= 10000)
-                    {
-                        var oneSecondEnqueueCount = periodicEnqueueCount / periodicUpdateTimer.Elapsed.TotalSeconds;
-                        logger.LogDebug($"Enqueues/sec: {oneSecondEnqueueCount:F2}, MB/sec: {(oneSecondEnqueueCount * ThunderscopeMemory.Length / 1000 / 1000):F3}, MiB/sec: {(oneSecondEnqueueCount * ThunderscopeMemory.Length / 1024 / 1024):F3}, enqueue count: {enqueueCounter}");
-                        periodicUpdateTimer.Restart();
-                        periodicEnqueueCount = 0;
-                    }
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                logger.LogDebug("Stopping...");
-            }
-            catch (Exception ex)
-            {
-                logger.LogCritical(ex, "Error");
-                throw;
-            }
-            finally
-            {
-                thunderscope.Stop();
-                logger.LogDebug("Stopped");
-            }
-        }
-    }
+					if (periodicUpdateTimer.ElapsedMilliseconds >= 10000)
+					{
+						var oneSecondEnqueueCount = periodicEnqueueCount / periodicUpdateTimer.Elapsed.TotalSeconds;
+						logger.LogDebug($"Enqueues/sec: {oneSecondEnqueueCount:F2}, MB/sec: {(oneSecondEnqueueCount * ThunderscopeMemory.Length / 1000 / 1000):F3}, MiB/sec: {(oneSecondEnqueueCount * ThunderscopeMemory.Length / 1024 / 1024):F3}, enqueue count: {enqueueCounter}");
+						periodicUpdateTimer.Restart();
+						periodicEnqueueCount = 0;
+					}
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				logger.LogDebug("Stopping...");
+			}
+			catch (Exception ex)
+			{
+				logger.LogCritical(ex, "Error");
+				throw;
+			}
+			finally
+			{
+				thunderscope.Stop();
+				logger.LogDebug("Stopped");
+			}
+		}
+	}
 }

--- a/source/TS.NET.Engine/Tasks/ProcessingThread.cs
+++ b/source/TS.NET.Engine/Tasks/ProcessingThread.cs
@@ -3,620 +3,626 @@ using System.Diagnostics;
 
 namespace TS.NET.Engine
 {
-    public class ProcessingThread
-    {
-        private readonly ILogger logger;
-        private readonly ThunderscopeSettings settings;
-        private readonly BlockingChannelReader<InputDataDto> processChannel;
-        private readonly BlockingChannelWriter<ThunderscopeMemory> inputChannel;
-        private readonly BlockingChannelReader<ProcessingRequestDto> processingRequestChannel;
-        private readonly BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel;
+	public class ProcessingThread
+	{
+		private readonly ILogger logger;
+		private readonly ThunderscopeSettings settings;
+		private readonly BlockingChannelReader<InputDataDto> processChannel;
+		private readonly BlockingChannelWriter<ThunderscopeMemory> inputChannel;
+		private readonly BlockingChannelReader<ProcessingRequestDto> processingRequestChannel;
+		private readonly BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel;
 
-        private CancellationTokenSource? cancelTokenSource;
-        private Task? taskLoop;
+		private CancellationTokenSource? cancelTokenSource;
+		private Task? taskLoop;
+		private int indexThunderscope;
 
-        public ProcessingThread(
-            ILoggerFactory loggerFactory,
-            ThunderscopeSettings settings,
-            BlockingChannelReader<InputDataDto> processChannel,
-            BlockingChannelWriter<ThunderscopeMemory> inputChannel,
-            BlockingChannelReader<ProcessingRequestDto> processingRequestChannel,
-            BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel)
-        {
-            logger = loggerFactory.CreateLogger(nameof(ProcessingThread));
-            this.settings = settings;
-            this.processChannel = processChannel;
-            this.inputChannel = inputChannel;
-            this.processingRequestChannel = processingRequestChannel;
-            this.processingResponseChannel = processingResponseChannel;
-        }
+		public ProcessingThread(
+			ILoggerFactory loggerFactory,
+			ThunderscopeSettings settings,
+			BlockingChannelReader<InputDataDto> processChannel,
+			BlockingChannelWriter<ThunderscopeMemory> inputChannel,
+			BlockingChannelReader<ProcessingRequestDto> processingRequestChannel,
+			BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel,
+			int indexThunderscope)
+		{
+			logger = loggerFactory.CreateLogger(nameof(ProcessingThread));
+			this.settings = settings;
+			this.processChannel = processChannel;
+			this.inputChannel = inputChannel;
+			this.processingRequestChannel = processingRequestChannel;
+			this.processingResponseChannel = processingResponseChannel;
+			this.indexThunderscope = indexThunderscope;
+			
+		}
 
-        public void Start(SemaphoreSlim startSemaphore)
-        {
-            cancelTokenSource = new CancellationTokenSource();
-            taskLoop = Task.Factory.StartNew(() => Loop(logger, settings, processChannel, inputChannel, processingRequestChannel, processingResponseChannel, startSemaphore, cancelTokenSource.Token), TaskCreationOptions.LongRunning);
-        }
+		public void Start(SemaphoreSlim startSemaphore)
+		{
+			cancelTokenSource = new CancellationTokenSource();
+			taskLoop = Task.Factory.StartNew(() => Loop(logger, settings, processChannel, inputChannel, processingRequestChannel, processingResponseChannel, startSemaphore, cancelTokenSource.Token, this.indexThunderscope), TaskCreationOptions.LongRunning);
+		}
 
-        public void Stop()
-        {
-            cancelTokenSource?.Cancel();
-            taskLoop?.Wait();
-        }
+		public void Stop()
+		{
+			cancelTokenSource?.Cancel();
+			taskLoop?.Wait();
+		}
 
-        // The job of this task - pull data from scope driver/simulator, shuffle if 2/4 channels, horizontal sum, trigger, and produce window segments.
-        private static void Loop(
-            ILogger logger,
-            ThunderscopeSettings settings,
-            BlockingChannelReader<InputDataDto> processChannel,
-            BlockingChannelWriter<ThunderscopeMemory> inputChannel,
-            BlockingChannelReader<ProcessingRequestDto> processingRequestChannel,
-            BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel,
-            SemaphoreSlim startSemaphore,
-            CancellationToken cancelToken)
-        {
-            try
-            {
-                Thread.CurrentThread.Name = nameof(ProcessingThread);
-                if (settings.ProcessingThreadProcessorAffinity > -1)
-                {
-                    Thread.BeginThreadAffinity();
-                    OsThread.SetThreadAffinity(settings.ProcessingThreadProcessorAffinity);
-                    logger.LogDebug($"{nameof(ProcessingThread)} thread processor affinity set to {settings.ProcessingThreadProcessorAffinity}");
-                }
+		// The job of this task - pull data from scope driver/simulator, shuffle if 2/4 channels, horizontal sum, trigger, and produce window segments.
+		private static void Loop(
+			ILogger logger,
+			ThunderscopeSettings settings,
+			BlockingChannelReader<InputDataDto> processChannel,
+			BlockingChannelWriter<ThunderscopeMemory> inputChannel,
+			BlockingChannelReader<ProcessingRequestDto> processingRequestChannel,
+			BlockingChannelWriter<ProcessingResponseDto> processingResponseChannel,
+			SemaphoreSlim startSemaphore,
+			CancellationToken cancelToken,
+			int indexThunderscope
+			)
+		{
+			try
+			{
+				Thread.CurrentThread.Name = nameof(ProcessingThread);
+				if (settings.ProcessingThreadProcessorAffinity > -1)
+				{
+					Thread.BeginThreadAffinity();
+					OsThread.SetThreadAffinity(settings.ProcessingThreadProcessorAffinity);
+					logger.LogDebug($"{nameof(ProcessingThread)} thread processor affinity set to {settings.ProcessingThreadProcessorAffinity}");
+				}
 
-                ThunderscopeDataBridgeConfig bridgeConfig = new()
-                {
-                    MaxChannelCount = settings.MaxChannelCount,
-                    MaxChannelDataLength = settings.MaxChannelDataLength,
-                    ChannelDataType = ThunderscopeChannelDataType.I8
-                };
-                ThunderscopeDataBridgeWriter bridge = new("ThunderScope.1", bridgeConfig);
+				ThunderscopeDataBridgeConfig bridgeConfig = new()
+				{
+					MaxChannelCount = settings.MaxChannelCount,
+					MaxChannelDataLength = settings.MaxChannelDataLength,
+					ChannelDataType = ThunderscopeChannelDataType.I8
+				};
+				ThunderscopeDataBridgeWriter bridge = new("ThunderScope."+indexThunderscope, bridgeConfig);
 
-                ThunderscopeHardwareConfig cachedHardwareConfig = default;
+				ThunderscopeHardwareConfig cachedHardwareConfig = default;
 
-                // Set some sensible defaults
-                var processingConfig = new ThunderscopeProcessingConfig
-                {
-                    CurrentChannelCount = settings.MaxChannelCount,
-                    CurrentChannelDataLength = settings.MaxChannelDataLength,
-                    TriggerChannel = TriggerChannel.Channel0,
-                    TriggerMode = TriggerMode.Auto,
-                    TriggerType = TriggerType.RisingEdge,
-                    TriggerDelayFs = 0,
-                    TriggerHysteresis = 5,
-                    TriggerHoldoff = 0,
-                    BoxcarAveraging = BoxcarAveraging.None
+				// Set some sensible defaults
+				var processingConfig = new ThunderscopeProcessingConfig
+				{
+					CurrentChannelCount = settings.MaxChannelCount,
+					CurrentChannelDataLength = settings.MaxChannelDataLength,
+					TriggerChannel = TriggerChannel.Channel0,
+					TriggerMode = TriggerMode.Auto,
+					TriggerType = TriggerType.RisingEdge,
+					TriggerDelayFs = 0,
+					TriggerHysteresis = 5,
+					TriggerHoldoff = 0,
+					BoxcarAveraging = BoxcarAveraging.None
 
-                };
-                bridge.Processing = processingConfig;
+				};
+				bridge.Processing = processingConfig;
 
-                // Reset monitoring
-                bridge.MonitoringReset();
+				// Reset monitoring
+				bridge.MonitoringReset();
 
-                // Various buffers allocated once and reused forevermore.
-                //Memory<byte> hardwareBuffer = new byte[ThunderscopeMemory.Length];
-                // Shuffle buffers. Only needed for 2/4 channel modes.
-                Span<sbyte> shuffleBuffer = new sbyte[ThunderscopeMemory.Length];
-                // --2 channel buffers
-                int blockLength_2 = (int)ThunderscopeMemory.Length / 2;
-                Span<sbyte> postShuffleCh1_2 = shuffleBuffer.Slice(0, blockLength_2);
-                Span<sbyte> postShuffleCh2_2 = shuffleBuffer.Slice(blockLength_2, blockLength_2);
-                // --4 channel buffers
-                int blockLength_4 = (int)ThunderscopeMemory.Length / 4;
-                Span<sbyte> postShuffleCh1_4 = shuffleBuffer.Slice(0, blockLength_4);
-                Span<sbyte> postShuffleCh2_4 = shuffleBuffer.Slice(blockLength_4, blockLength_4);
-                Span<sbyte> postShuffleCh3_4 = shuffleBuffer.Slice(blockLength_4 * 2, blockLength_4);
-                Span<sbyte> postShuffleCh4_4 = shuffleBuffer.Slice(blockLength_4 * 3, blockLength_4);
-                Span<uint> captureEndIndices = new uint[ThunderscopeMemory.Length / 1000];  // 1000 samples is the minimum window width
+				// Various buffers allocated once and reused forevermore.
+				//Memory<byte> hardwareBuffer = new byte[ThunderscopeMemory.Length];
+				// Shuffle buffers. Only needed for 2/4 channel modes.
+				Span<sbyte> shuffleBuffer = new sbyte[ThunderscopeMemory.Length];
+				// --2 channel buffers
+				int blockLength_2 = (int)ThunderscopeMemory.Length / 2;
+				Span<sbyte> postShuffleCh1_2 = shuffleBuffer.Slice(0, blockLength_2);
+				Span<sbyte> postShuffleCh2_2 = shuffleBuffer.Slice(blockLength_2, blockLength_2);
+				// --4 channel buffers
+				int blockLength_4 = (int)ThunderscopeMemory.Length / 4;
+				Span<sbyte> postShuffleCh1_4 = shuffleBuffer.Slice(0, blockLength_4);
+				Span<sbyte> postShuffleCh2_4 = shuffleBuffer.Slice(blockLength_4, blockLength_4);
+				Span<sbyte> postShuffleCh3_4 = shuffleBuffer.Slice(blockLength_4 * 2, blockLength_4);
+				Span<sbyte> postShuffleCh4_4 = shuffleBuffer.Slice(blockLength_4 * 3, blockLength_4);
+				Span<uint> captureEndIndices = new uint[ThunderscopeMemory.Length / 1000];  // 1000 samples is the minimum window width
 
-                // Periodic debug display variables
-                DateTimeOffset startTime = DateTimeOffset.UtcNow;
-                ulong totalDequeueCount = 0;
-                ulong cachedTotalDequeueCount = 0;
-                ulong cachedTotalAcquisitions = 0;
-                ulong cachedMissedAcquisitions = 0;
-                Stopwatch periodicUpdateTimer = Stopwatch.StartNew();
+				// Periodic debug display variables
+				DateTimeOffset startTime = DateTimeOffset.UtcNow;
+				ulong totalDequeueCount = 0;
+				ulong cachedTotalDequeueCount = 0;
+				ulong cachedTotalAcquisitions = 0;
+				ulong cachedMissedAcquisitions = 0;
+				Stopwatch periodicUpdateTimer = Stopwatch.StartNew();
 
-                var circularBuffer1 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
-                var circularBuffer2 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
-                var circularBuffer3 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
-                var circularBuffer4 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
+				var circularBuffer1 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
+				var circularBuffer2 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
+				var circularBuffer3 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
+				var circularBuffer4 = new ChannelCircularAlignedBufferI8((uint)processingConfig.CurrentChannelDataLength + ThunderscopeMemory.Length);
 
-                // Triggering:
-                // There are 3 states for Trigger Mode: normal, single, auto.
-                // (these only run during Start, not during Stop. Invoking Force will ignore Start/Stop.)
-                // Normal: wait for trigger indefinately and run continuously.
-                // Single: wait for trigger indefinately and then stop.
-                // Auto: wait for trigger indefinately, push update when timeout occurs, and run continously.
-                //
-                // runTrigger: enables/disables trigger subsystem. 
-                // forceTriggerLatch: disregards the Trigger Mode, push update immediately and set forceTrigger to false. If a standard trigger happened at the same time as a force, the force is ignored so the bridge only updates once.
-                // singleTriggerLatch: used in Single mode to stop the trigger subsystem after a trigger.
+				// Triggering:
+				// There are 3 states for Trigger Mode: normal, single, auto.
+				// (these only run during Start, not during Stop. Invoking Force will ignore Start/Stop.)
+				// Normal: wait for trigger indefinately and run continuously.
+				// Single: wait for trigger indefinately and then stop.
+				// Auto: wait for trigger indefinately, push update when timeout occurs, and run continously.
+				//
+				// runTrigger: enables/disables trigger subsystem. 
+				// forceTriggerLatch: disregards the Trigger Mode, push update immediately and set forceTrigger to false. If a standard trigger happened at the same time as a force, the force is ignored so the bridge only updates once.
+				// singleTriggerLatch: used in Single mode to stop the trigger subsystem after a trigger.
 
-                AdcChannelMode cachedAdcChannelMode = AdcChannelMode.Quad;
-                RisingEdgeTriggerI8_v2 risingEdgeTrigger = new(5, processingConfig.TriggerHysteresis, processingConfig.CurrentChannelDataLength, 0, processingConfig.TriggerHoldoff);
-                FallingEdgeTriggerI8_v2 fallingEdgeTrigger = new(5, processingConfig.TriggerHysteresis, processingConfig.CurrentChannelDataLength, 0, processingConfig.TriggerHoldoff);
-                bool runMode = true;
-                bool forceTriggerLatch = false;     // "Latch" because it will reset state back to false. If the force is invoked and a trigger happens anyway, it will be reset (effectively ignoring it and only updating the bridge once).
-                bool singleTriggerLatch = false;    // "Latch" because it will reset state back to false. When reset, runTrigger will be set to false.
+				AdcChannelMode cachedAdcChannelMode = AdcChannelMode.Quad;
+				RisingEdgeTriggerI8_v2 risingEdgeTrigger = new(5, processingConfig.TriggerHysteresis, processingConfig.CurrentChannelDataLength, 0, processingConfig.TriggerHoldoff);
+				FallingEdgeTriggerI8_v2 fallingEdgeTrigger = new(5, processingConfig.TriggerHysteresis, processingConfig.CurrentChannelDataLength, 0, processingConfig.TriggerHoldoff);
+				bool runMode = true;
+				bool forceTriggerLatch = false;     // "Latch" because it will reset state back to false. If the force is invoked and a trigger happens anyway, it will be reset (effectively ignoring it and only updating the bridge once).
+				bool singleTriggerLatch = false;    // "Latch" because it will reset state back to false. When reset, runTrigger will be set to false.
 
-                // Variables for Auto triggering
-                Stopwatch autoTimeoutTimer = Stopwatch.StartNew();
-                int streamSampleCounter = 0;
-                long autoTimeout = 500;
+				// Variables for Auto triggering
+				Stopwatch autoTimeoutTimer = Stopwatch.StartNew();
+				int streamSampleCounter = 0;
+				long autoTimeout = 500;
 
-                logger.LogInformation("Started");
-                startSemaphore.Release();
+				logger.LogInformation("Started");
+				startSemaphore.Release();
 
-                while (true)
-                {
-                    cancelToken.ThrowIfCancellationRequested();
+				while (true)
+				{
+					cancelToken.ThrowIfCancellationRequested();
 
-                    // Check for processing requests
-                    if (processingRequestChannel.TryRead(out var request))
-                    {
-                        switch (request)
-                        {
-                            case ProcessingRunDto processingStartTriggerDto:
-                                runMode = true;
-                                logger.LogDebug($"{nameof(ProcessingRunDto)}");
-                                break;
-                            case ProcessingStopDto processingStopTriggerDto:
-                                runMode = false;
-                                logger.LogDebug($"{nameof(ProcessingStopDto)}");
-                                break;
-                            case ProcessingForceTriggerDto processingForceTriggerDto:
-                                forceTriggerLatch = true;
-                                logger.LogDebug($"{nameof(ProcessingForceTriggerDto)}");
-                                break;
-                            case ProcessingSetTriggerModeDto processingSetTriggerModeDto:
-                                processingConfig.TriggerMode = processingSetTriggerModeDto.Mode;
-                                switch (processingSetTriggerModeDto.Mode)
-                                {
-                                    case TriggerMode.Normal:
-                                    case TriggerMode.Stream:
-                                        singleTriggerLatch = false;
-                                        break;
-                                    case TriggerMode.Single:
-                                        singleTriggerLatch = true;
-                                        break;
-                                    case TriggerMode.Auto:
-                                        singleTriggerLatch = false;
-                                        autoTimeoutTimer.Restart();
-                                        break;
-                                }
-                                logger.LogDebug($"{nameof(ProcessingSetTriggerModeDto)} (mode: {processingConfig.TriggerMode})");
-                                break;
-                            case ProcessingSetDepthDto processingSetDepthDto:
-                                if (processingConfig.CurrentChannelDataLength != processingSetDepthDto.Samples)
-                                {
-                                    processingConfig.CurrentChannelDataLength = processingSetDepthDto.Samples;
-                                    UpdateTriggerHorizontalPosition();
-                                    logger.LogDebug($"{nameof(ProcessingSetDepthDto)} ({processingConfig.CurrentChannelDataLength})");
-                                }
-                                logger.LogDebug($"{nameof(ProcessingSetDepthDto)} (no change)");
-                                break;
-                            case ProcessingSetRateDto processingSetRateDto:
-                                var rate = processingSetRateDto.SamplingHz;
-                                logger.LogWarning($"{nameof(ProcessingSetRateDto)} [Not implemented]");
-                                break;
-                            case ProcessingSetTriggerSourceDto processingSetTriggerSourceDto:
-                                processingConfig.TriggerChannel = processingSetTriggerSourceDto.Channel;
-                                logger.LogDebug($"{nameof(ProcessingSetTriggerSourceDto)} (channel: {processingConfig.TriggerChannel})");
-                                break;
-                            case ProcessingSetTriggerDelayDto processingSetTriggerDelayDto:
-                                if (processingConfig.TriggerDelayFs != processingSetTriggerDelayDto.Femtoseconds)
-                                {
-                                    processingConfig.TriggerDelayFs = processingSetTriggerDelayDto.Femtoseconds;
-                                    UpdateTriggerHorizontalPosition();
-                                    logger.LogDebug($"{nameof(ProcessingSetTriggerDelayDto)} (femtoseconds: {processingConfig.TriggerDelayFs})");
-                                }
-                                logger.LogDebug($"{nameof(ProcessingSetTriggerDelayDto)} (no change)");
-                                break;
-                            case ProcessingSetTriggerLevelDto processingSetTriggerLevelDto:
-                                var requestedTriggerLevel = processingSetTriggerLevelDto.LevelVolts;
-                                // Convert the voltage to Int8
+					// Check for processing requests
+					if (processingRequestChannel.TryRead(out var request))
+					{
+						switch (request)
+						{
+							case ProcessingRunDto processingStartTriggerDto:
+								runMode = true;
+								logger.LogDebug($"{nameof(ProcessingRunDto)}");
+								break;
+							case ProcessingStopDto processingStopTriggerDto:
+								runMode = false;
+								logger.LogDebug($"{nameof(ProcessingStopDto)}");
+								break;
+							case ProcessingForceTriggerDto processingForceTriggerDto:
+								forceTriggerLatch = true;
+								logger.LogDebug($"{nameof(ProcessingForceTriggerDto)}");
+								break;
+							case ProcessingSetTriggerModeDto processingSetTriggerModeDto:
+								processingConfig.TriggerMode = processingSetTriggerModeDto.Mode;
+								switch (processingSetTriggerModeDto.Mode)
+								{
+									case TriggerMode.Normal:
+									case TriggerMode.Stream:
+										singleTriggerLatch = false;
+										break;
+									case TriggerMode.Single:
+										singleTriggerLatch = true;
+										break;
+									case TriggerMode.Auto:
+										singleTriggerLatch = false;
+										autoTimeoutTimer.Restart();
+										break;
+								}
+								logger.LogDebug($"{nameof(ProcessingSetTriggerModeDto)} (mode: {processingConfig.TriggerMode})");
+								break;
+							case ProcessingSetDepthDto processingSetDepthDto:
+								if (processingConfig.CurrentChannelDataLength != processingSetDepthDto.Samples)
+								{
+									processingConfig.CurrentChannelDataLength = processingSetDepthDto.Samples;
+									UpdateTriggerHorizontalPosition();
+									logger.LogDebug($"{nameof(ProcessingSetDepthDto)} ({processingConfig.CurrentChannelDataLength})");
+								}
+								logger.LogDebug($"{nameof(ProcessingSetDepthDto)} (no change)");
+								break;
+							case ProcessingSetRateDto processingSetRateDto:
+								var rate = processingSetRateDto.SamplingHz;
+								logger.LogWarning($"{nameof(ProcessingSetRateDto)} [Not implemented]");
+								break;
+							case ProcessingSetTriggerSourceDto processingSetTriggerSourceDto:
+								processingConfig.TriggerChannel = processingSetTriggerSourceDto.Channel;
+								logger.LogDebug($"{nameof(ProcessingSetTriggerSourceDto)} (channel: {processingConfig.TriggerChannel})");
+								break;
+							case ProcessingSetTriggerDelayDto processingSetTriggerDelayDto:
+								if (processingConfig.TriggerDelayFs != processingSetTriggerDelayDto.Femtoseconds)
+								{
+									processingConfig.TriggerDelayFs = processingSetTriggerDelayDto.Femtoseconds;
+									UpdateTriggerHorizontalPosition();
+									logger.LogDebug($"{nameof(ProcessingSetTriggerDelayDto)} (femtoseconds: {processingConfig.TriggerDelayFs})");
+								}
+								logger.LogDebug($"{nameof(ProcessingSetTriggerDelayDto)} (no change)");
+								break;
+							case ProcessingSetTriggerLevelDto processingSetTriggerLevelDto:
+								var requestedTriggerLevel = processingSetTriggerLevelDto.LevelVolts;
+								// Convert the voltage to Int8
 
-                                var triggerChannel = cachedHardwareConfig.GetTriggerChannel(processingConfig.TriggerChannel);
+								var triggerChannel = cachedHardwareConfig.GetTriggerChannel(processingConfig.TriggerChannel);
 
-                                if ((requestedTriggerLevel > triggerChannel.ActualVoltFullScale / 2) || (requestedTriggerLevel < -triggerChannel.ActualVoltFullScale / 2))
-                                {
-                                    logger.LogWarning($"Could not set trigger level {requestedTriggerLevel}");
-                                    break;
-                                }
+								if ((requestedTriggerLevel > triggerChannel.ActualVoltFullScale / 2) || (requestedTriggerLevel < -triggerChannel.ActualVoltFullScale / 2))
+								{
+									logger.LogWarning($"Could not set trigger level {requestedTriggerLevel}");
+									break;
+								}
 
-                                sbyte triggerLevel = (sbyte)((requestedTriggerLevel / (triggerChannel.ActualVoltFullScale / 2)) * 127f);
-                                if (triggerLevel != processingConfig.TriggerLevel)
-                                {
-                                    processingConfig.TriggerLevel = triggerLevel;
-                                    risingEdgeTrigger.SetVertical(triggerLevel, processingConfig.TriggerHysteresis);
-                                    fallingEdgeTrigger.SetVertical(triggerLevel, processingConfig.TriggerHysteresis);
-                                    logger.LogDebug($"{nameof(ProcessingSetTriggerLevelDto)} (level: {triggerLevel}, hysteresis: {processingConfig.TriggerHysteresis})");
-                                }
-                                logger.LogDebug($"{nameof(ProcessingSetTriggerLevelDto)} (no change)");
-                                break;
-                            case ProcessingSetTriggerTypeDto processingSetTriggerTypeDto:
-                                processingConfig.TriggerType = processingSetTriggerTypeDto.Type;
-                                logger.LogDebug($"{nameof(ProcessingSetTriggerTypeDto)} (type: {processingConfig.TriggerType})");
-                                break;
-                            case ProcessingGetRateRequestDto processingGetRateRequestDto:
-                                logger.LogDebug($"{nameof(ProcessingGetRateRequestDto)}");
-                                switch (cachedHardwareConfig.AdcChannelMode)
-                                {
-                                    case AdcChannelMode.Single:
-                                        processingResponseChannel.Write(new ProcessingGetRateResponseDto(1000000000));
-                                        break;
-                                    case AdcChannelMode.Dual:
-                                        processingResponseChannel.Write(new ProcessingGetRateResponseDto(500000000));
-                                        break;
-                                    case AdcChannelMode.Quad:
-                                        processingResponseChannel.Write(new ProcessingGetRateResponseDto(250000000));
-                                        break;
-                                }
-                                logger.LogDebug($"{nameof(ProcessingGetRateResponseDto)}");
-                                break;
-                            default:
-                                logger.LogWarning($"Unknown ProcessingRequestDto: {request}");
-                                break;
-                        }
+								sbyte triggerLevel = (sbyte)((requestedTriggerLevel / (triggerChannel.ActualVoltFullScale / 2)) * 127f);
+								if (triggerLevel != processingConfig.TriggerLevel)
+								{
+									processingConfig.TriggerLevel = triggerLevel;
+									risingEdgeTrigger.SetVertical(triggerLevel, processingConfig.TriggerHysteresis);
+									fallingEdgeTrigger.SetVertical(triggerLevel, processingConfig.TriggerHysteresis);
+									logger.LogDebug($"{nameof(ProcessingSetTriggerLevelDto)} (level: {triggerLevel}, hysteresis: {processingConfig.TriggerHysteresis})");
+								}
+								logger.LogDebug($"{nameof(ProcessingSetTriggerLevelDto)} (no change)");
+								break;
+							case ProcessingSetTriggerTypeDto processingSetTriggerTypeDto:
+								processingConfig.TriggerType = processingSetTriggerTypeDto.Type;
+								logger.LogDebug($"{nameof(ProcessingSetTriggerTypeDto)} (type: {processingConfig.TriggerType})");
+								break;
+							case ProcessingGetRateRequestDto processingGetRateRequestDto:
+								logger.LogDebug($"{nameof(ProcessingGetRateRequestDto)}");
+								switch (cachedHardwareConfig.AdcChannelMode)
+								{
+									case AdcChannelMode.Single:
+										processingResponseChannel.Write(new ProcessingGetRateResponseDto(1000000000));
+										break;
+									case AdcChannelMode.Dual:
+										processingResponseChannel.Write(new ProcessingGetRateResponseDto(500000000));
+										break;
+									case AdcChannelMode.Quad:
+										processingResponseChannel.Write(new ProcessingGetRateResponseDto(250000000));
+										break;
+								}
+								logger.LogDebug($"{nameof(ProcessingGetRateResponseDto)}");
+								break;
+							default:
+								logger.LogWarning($"Unknown ProcessingRequestDto: {request}");
+								break;
+						}
 
-                        bridge.Processing = processingConfig;
-                    }
+						bridge.Processing = processingConfig;
+					}
 
-                    if (processChannel.TryRead(out InputDataDto inputDataDto, 10, cancelToken))
-                    {
-                        cachedHardwareConfig = inputDataDto.HardwareConfig;
-                        bridge.Hardware = inputDataDto.HardwareConfig;
-                        totalDequeueCount++;
+					if (processChannel.TryRead(out InputDataDto inputDataDto, 10, cancelToken))
+					{
+						cachedHardwareConfig = inputDataDto.HardwareConfig;
+						bridge.Hardware = inputDataDto.HardwareConfig;
+						totalDequeueCount++;
 
-                        if (inputDataDto.HardwareConfig.AdcChannelMode != cachedAdcChannelMode)
-                        {
-                            // If the AdcChannelMode changes (i.e. sample rate changes) then update horizontal trigger positions
-                            cachedAdcChannelMode = inputDataDto.HardwareConfig.AdcChannelMode;
-                            UpdateTriggerHorizontalPosition();
-                        }
+						if (inputDataDto.HardwareConfig.AdcChannelMode != cachedAdcChannelMode)
+						{
+							// If the AdcChannelMode changes (i.e. sample rate changes) then update horizontal trigger positions
+							cachedAdcChannelMode = inputDataDto.HardwareConfig.AdcChannelMode;
+							UpdateTriggerHorizontalPosition();
+						}
 
-                        int channelLength = (int)processingConfig.CurrentChannelDataLength;
-                        switch (inputDataDto.HardwareConfig.AdcChannelMode)
-                        {
-                            // Processing pipeline:
-                            // Shuffle (if needed)
-                            // Horizontal sum (EDIT: triggering should happen _before_ horizontal sum)
-                            // Write to circular buffer
-                            // Trigger
-                            // Data segment on trigger (if needed)
-                            case AdcChannelMode.Single:
-                                // Copy
-                                inputDataDto.Memory.SpanI8.CopyTo(shuffleBuffer);
-                                // Finished with the memory, return it
-                                inputChannel.Write(inputDataDto.Memory);
-                                // Write to circular buffer
-                                circularBuffer1.Write(shuffleBuffer);
-                                streamSampleCounter += shuffleBuffer.Length;
-                                // Trigger
-                                if (runMode)
-                                {
-                                    switch (processingConfig.TriggerMode)
-                                    {
-                                        case TriggerMode.Normal:
-                                        case TriggerMode.Single:
-                                        case TriggerMode.Auto:
-                                            if (cachedHardwareConfig.IsTriggerChannelAnEnabledChannel(processingConfig.TriggerChannel))
-                                            {
-                                                var triggerChannelBuffer = shuffleBuffer;
+						int channelLength = (int)processingConfig.CurrentChannelDataLength;
+						switch (inputDataDto.HardwareConfig.AdcChannelMode)
+						{
+							// Processing pipeline:
+							// Shuffle (if needed)
+							// Horizontal sum (EDIT: triggering should happen _before_ horizontal sum)
+							// Write to circular buffer
+							// Trigger
+							// Data segment on trigger (if needed)
+							case AdcChannelMode.Single:
+								// Copy
+								inputDataDto.Memory.SpanI8.CopyTo(shuffleBuffer);
+								// Finished with the memory, return it
+								inputChannel.Write(inputDataDto.Memory);
+								// Write to circular buffer
+								circularBuffer1.Write(shuffleBuffer);
+								streamSampleCounter += shuffleBuffer.Length;
+								// Trigger
+								if (runMode)
+								{
+									switch (processingConfig.TriggerMode)
+									{
+										case TriggerMode.Normal:
+										case TriggerMode.Single:
+										case TriggerMode.Auto:
+											if (cachedHardwareConfig.IsTriggerChannelAnEnabledChannel(processingConfig.TriggerChannel))
+											{
+												var triggerChannelBuffer = shuffleBuffer;
 
-                                                uint captureEndCount = 0;
-                                                switch (processingConfig.TriggerType)
-                                                {
-                                                    case TriggerType.RisingEdge:
-                                                        risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                    case TriggerType.FallingEdge:
-                                                        fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                }
+												uint captureEndCount = 0;
+												switch (processingConfig.TriggerType)
+												{
+													case TriggerType.RisingEdge:
+														risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+													case TriggerType.FallingEdge:
+														fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+												}
 
-                                                if (captureEndCount > 0)
-                                                {
-                                                    for (int i = 0; i < captureEndCount; i++)
-                                                    {
-                                                        var bridgeSpan = bridge.AcquiringRegionI8;
-                                                        uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
-                                                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
-                                                        bridge.DataWritten();
-                                                        bridge.SwitchRegionIfNeeded();
+												if (captureEndCount > 0)
+												{
+													for (int i = 0; i < captureEndCount; i++)
+													{
+														var bridgeSpan = bridge.AcquiringRegionI8;
+														uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
+														circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
+														bridge.DataWritten();
+														bridge.SwitchRegionIfNeeded();
 
-                                                        if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
-                                                        {
-                                                            singleTriggerLatch = false;
-                                                            runMode = false;
-                                                            break;
-                                                        }
-                                                    }
-                                                    streamSampleCounter = 0;
-                                                    autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
-                                                }
-                                            }
-                                            if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
-                                            {
-                                                var bridgeSpan = bridge.AcquiringRegionI8;
-                                                circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
-                                                bridge.DataWritten();
-                                                bridge.SwitchRegionIfNeeded();
-                                                forceTriggerLatch = false;
+														if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
+														{
+															singleTriggerLatch = false;
+															runMode = false;
+															break;
+														}
+													}
+													streamSampleCounter = 0;
+													autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
+												}
+											}
+											if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
+											{
+												var bridgeSpan = bridge.AcquiringRegionI8;
+												circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
+												bridge.DataWritten();
+												bridge.SwitchRegionIfNeeded();
+												forceTriggerLatch = false;
 
-                                                streamSampleCounter = 0;
-                                                autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
-                                            }
-                                            if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
-                                            {
-                                                SingleChannelStream(channelLength);
-                                            }
-                                            break;
-                                        case TriggerMode.Stream:
-                                            SingleChannelStream(channelLength);
-                                            break;
-                                    }
-                                }
-                                break;
-                            case AdcChannelMode.Dual:
-                                // Shuffle
-                                Shuffle.TwoChannels(input: inputDataDto.Memory.SpanI8, output: shuffleBuffer);
-                                // Finished with the memory, return it
-                                inputChannel.Write(inputDataDto.Memory);
-                                // Write to circular buffer
-                                circularBuffer1.Write(postShuffleCh1_2);
-                                circularBuffer2.Write(postShuffleCh2_2);
-                                streamSampleCounter += postShuffleCh1_2.Length;
-                                // Trigger
-                                if (runMode)
-                                {
-                                    switch (processingConfig.TriggerMode)
-                                    {
-                                        case TriggerMode.Normal:
-                                        case TriggerMode.Single:
-                                        case TriggerMode.Auto:
-                                            if (cachedHardwareConfig.IsTriggerChannelAnEnabledChannel(processingConfig.TriggerChannel))
-                                            {
-                                                var triggerChannelBuffer = postShuffleCh2_2;
-                                                if (cachedHardwareConfig.DualChannelModeIsTriggerChannelInFirstPosition(processingConfig.TriggerChannel))
-                                                    triggerChannelBuffer = postShuffleCh1_2;
+												streamSampleCounter = 0;
+												autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
+											}
+											if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
+											{
+												SingleChannelStream(channelLength);
+											}
+											break;
+										case TriggerMode.Stream:
+											SingleChannelStream(channelLength);
+											break;
+									}
+								}
+								break;
+							case AdcChannelMode.Dual:
+								// Shuffle
+								Shuffle.TwoChannels(input: inputDataDto.Memory.SpanI8, output: shuffleBuffer);
+								// Finished with the memory, return it
+								inputChannel.Write(inputDataDto.Memory);
+								// Write to circular buffer
+								circularBuffer1.Write(postShuffleCh1_2);
+								circularBuffer2.Write(postShuffleCh2_2);
+								streamSampleCounter += postShuffleCh1_2.Length;
+								// Trigger
+								if (runMode)
+								{
+									switch (processingConfig.TriggerMode)
+									{
+										case TriggerMode.Normal:
+										case TriggerMode.Single:
+										case TriggerMode.Auto:
+											if (cachedHardwareConfig.IsTriggerChannelAnEnabledChannel(processingConfig.TriggerChannel))
+											{
+												var triggerChannelBuffer = postShuffleCh2_2;
+												if (cachedHardwareConfig.DualChannelModeIsTriggerChannelInFirstPosition(processingConfig.TriggerChannel))
+													triggerChannelBuffer = postShuffleCh1_2;
 
-                                                uint captureEndCount = 0;
-                                                switch (processingConfig.TriggerType)
-                                                {
-                                                    case TriggerType.RisingEdge:
-                                                        risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                    case TriggerType.FallingEdge:
-                                                        fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                }
+												uint captureEndCount = 0;
+												switch (processingConfig.TriggerType)
+												{
+													case TriggerType.RisingEdge:
+														risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+													case TriggerType.FallingEdge:
+														fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+												}
 
-                                                if (captureEndCount > 0)
-                                                {
-                                                    for (int i = 0; i < captureEndCount; i++)
-                                                    {
-                                                        var bridgeSpan = bridge.AcquiringRegionI8;
-                                                        uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
-                                                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
-                                                        circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), endOffset);
-                                                        bridge.DataWritten();
-                                                        bridge.SwitchRegionIfNeeded();
+												if (captureEndCount > 0)
+												{
+													for (int i = 0; i < captureEndCount; i++)
+													{
+														var bridgeSpan = bridge.AcquiringRegionI8;
+														uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
+														circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
+														circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), endOffset);
+														bridge.DataWritten();
+														bridge.SwitchRegionIfNeeded();
 
-                                                        if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
-                                                        {
-                                                            singleTriggerLatch = false;
-                                                            runMode = false;
-                                                            break;
-                                                        }
-                                                    }
-                                                    streamSampleCounter = 0;
-                                                    autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
-                                                }
-                                            }
-                                            if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
-                                            {
-                                                var bridgeSpan = bridge.AcquiringRegionI8;
-                                                circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
-                                                circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
-                                                bridge.DataWritten();
-                                                bridge.SwitchRegionIfNeeded();
-                                                forceTriggerLatch = false;
+														if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
+														{
+															singleTriggerLatch = false;
+															runMode = false;
+															break;
+														}
+													}
+													streamSampleCounter = 0;
+													autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
+												}
+											}
+											if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
+											{
+												var bridgeSpan = bridge.AcquiringRegionI8;
+												circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
+												circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
+												bridge.DataWritten();
+												bridge.SwitchRegionIfNeeded();
+												forceTriggerLatch = false;
 
-                                                streamSampleCounter = 0;
-                                                autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
-                                            }
-                                            if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
-                                            {
-                                                DualChannelStream(channelLength);
-                                            }
-                                            break;
-                                        case TriggerMode.Stream:
-                                            DualChannelStream(channelLength);
-                                            break;
-                                    }
-                                }
-                                break;
-                            case AdcChannelMode.Quad:
-                                // Shuffle
-                                Shuffle.FourChannels(input: inputDataDto.Memory.SpanI8, output: shuffleBuffer);
-                                // Finished with the memory, return it
-                                inputChannel.Write(inputDataDto.Memory);
-                                // Write to circular buffer
-                                circularBuffer1.Write(postShuffleCh1_4);
-                                circularBuffer2.Write(postShuffleCh2_4);
-                                circularBuffer3.Write(postShuffleCh3_4);
-                                circularBuffer4.Write(postShuffleCh4_4);
-                                streamSampleCounter += postShuffleCh1_4.Length;
-                                // Trigger
-                                if (runMode)
-                                {
-                                    switch (processingConfig.TriggerMode)
-                                    {
-                                        case TriggerMode.Normal:
-                                        case TriggerMode.Single:
-                                        case TriggerMode.Auto:
-                                            if (processingConfig.TriggerChannel != TriggerChannel.NotSet)
-                                            {
-                                                var triggerChannelBuffer = processingConfig.TriggerChannel switch
-                                                {
-                                                    TriggerChannel.Channel0 => postShuffleCh1_4,
-                                                    TriggerChannel.Channel1 => postShuffleCh2_4,
-                                                    TriggerChannel.Channel2 => postShuffleCh3_4,
-                                                    TriggerChannel.Channel3 => postShuffleCh4_4,
-                                                    _ => throw new ArgumentException("Invalid TriggerChannel value")
-                                                };
+												streamSampleCounter = 0;
+												autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
+											}
+											if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
+											{
+												DualChannelStream(channelLength);
+											}
+											break;
+										case TriggerMode.Stream:
+											DualChannelStream(channelLength);
+											break;
+									}
+								}
+								break;
+							case AdcChannelMode.Quad:
+								// Shuffle
+								Shuffle.FourChannels(input: inputDataDto.Memory.SpanI8, output: shuffleBuffer);
+								// Finished with the memory, return it
+								inputChannel.Write(inputDataDto.Memory);
+								// Write to circular buffer
+								circularBuffer1.Write(postShuffleCh1_4);
+								circularBuffer2.Write(postShuffleCh2_4);
+								circularBuffer3.Write(postShuffleCh3_4);
+								circularBuffer4.Write(postShuffleCh4_4);
+								streamSampleCounter += postShuffleCh1_4.Length;
+								// Trigger
+								if (runMode)
+								{
+									switch (processingConfig.TriggerMode)
+									{
+										case TriggerMode.Normal:
+										case TriggerMode.Single:
+										case TriggerMode.Auto:
+											if (processingConfig.TriggerChannel != TriggerChannel.NotSet)
+											{
+												var triggerChannelBuffer = processingConfig.TriggerChannel switch
+												{
+													TriggerChannel.Channel0 => postShuffleCh1_4,
+													TriggerChannel.Channel1 => postShuffleCh2_4,
+													TriggerChannel.Channel2 => postShuffleCh3_4,
+													TriggerChannel.Channel3 => postShuffleCh4_4,
+													_ => throw new ArgumentException("Invalid TriggerChannel value")
+												};
 
-                                                uint captureEndCount = 0;
-                                                switch (processingConfig.TriggerType)
-                                                {
-                                                    case TriggerType.RisingEdge:
-                                                        risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                    case TriggerType.FallingEdge:
-                                                        fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
-                                                        break;
-                                                }
+												uint captureEndCount = 0;
+												switch (processingConfig.TriggerType)
+												{
+													case TriggerType.RisingEdge:
+														risingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+													case TriggerType.FallingEdge:
+														fallingEdgeTrigger.ProcessSimd(input: triggerChannelBuffer, captureEndIndices: captureEndIndices, out captureEndCount);
+														break;
+												}
 
-                                                if (captureEndCount > 0)
-                                                {
-                                                    for (int i = 0; i < captureEndCount; i++)
-                                                    {
-                                                        var bridgeSpan = bridge.AcquiringRegionI8;
-                                                        uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
-                                                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
-                                                        circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), endOffset);
-                                                        circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), endOffset);
-                                                        circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), endOffset);
-                                                        bridge.DataWritten();
-                                                        bridge.SwitchRegionIfNeeded();
+												if (captureEndCount > 0)
+												{
+													for (int i = 0; i < captureEndCount; i++)
+													{
+														var bridgeSpan = bridge.AcquiringRegionI8;
+														uint endOffset = (uint)triggerChannelBuffer.Length - captureEndIndices[i];
+														circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), endOffset);
+														circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), endOffset);
+														circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), endOffset);
+														circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), endOffset);
+														bridge.DataWritten();
+														bridge.SwitchRegionIfNeeded();
 
-                                                        if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
-                                                        {
-                                                            singleTriggerLatch = false;
-                                                            runMode = false;
-                                                            break;
-                                                        }
-                                                    }
-                                                    streamSampleCounter = 0;
-                                                    autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
-                                                }
-                                            }
-                                            if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
-                                            {
-                                                var bridgeSpan = bridge.AcquiringRegionI8;
-                                                circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
-                                                circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
-                                                circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), 0);
-                                                circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), 0);
-                                                bridge.DataWritten();
-                                                bridge.SwitchRegionIfNeeded();
-                                                forceTriggerLatch = false;
+														if (singleTriggerLatch)         // If this was a single trigger, reset the singleTrigger & runTrigger latches
+														{
+															singleTriggerLatch = false;
+															runMode = false;
+															break;
+														}
+													}
+													streamSampleCounter = 0;
+													autoTimeoutTimer.Restart();     // Restart the auto timeout as a normal trigger happened
+												}
+											}
+											if (forceTriggerLatch) // This will always run, despite whether a trigger has happened or not (so from the user perspective, the UI might show one misaligned waveform during normal triggering; this is intended)
+											{
+												var bridgeSpan = bridge.AcquiringRegionI8;
+												circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);
+												circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
+												circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), 0);
+												circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), 0);
+												bridge.DataWritten();
+												bridge.SwitchRegionIfNeeded();
+												forceTriggerLatch = false;
 
-                                                streamSampleCounter = 0;
-                                                autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
-                                            }
-                                            if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
-                                            {
-                                                QuadChannelStream(channelLength);
-                                            }
-                                            break;
-                                        case TriggerMode.Stream:
-                                            QuadChannelStream(channelLength);
-                                            break;
-                                    }
-                                }
-                                break;
-                        }
-                        bridge.SwitchRegionIfNeeded();      // This ensures the semaphore is serviced on every loop iteration
-                        if (periodicUpdateTimer.ElapsedMilliseconds >= 10000)
-                        {
-                            var dequeueCount = totalDequeueCount - cachedTotalDequeueCount;
-                            var totalAcquisitions = bridge.Monitoring.TotalAcquisitions - cachedTotalAcquisitions;
-                            var missedAcquisitions = bridge.Monitoring.DroppedAcquisitions - cachedMissedAcquisitions;
-                            var uiUpdates = totalAcquisitions - missedAcquisitions;
+												streamSampleCounter = 0;
+												autoTimeoutTimer.Restart();     // Restart the auto timeout as a force trigger happened
+											}
+											if (processingConfig.TriggerMode == TriggerMode.Auto && autoTimeoutTimer.ElapsedMilliseconds > autoTimeout)
+											{
+												QuadChannelStream(channelLength);
+											}
+											break;
+										case TriggerMode.Stream:
+											QuadChannelStream(channelLength);
+											break;
+									}
+								}
+								break;
+						}
+						bridge.SwitchRegionIfNeeded();      // This ensures the semaphore is serviced on every loop iteration
+						if (periodicUpdateTimer.ElapsedMilliseconds >= 10000)
+						{
+							var dequeueCount = totalDequeueCount - cachedTotalDequeueCount;
+							var totalAcquisitions = bridge.Monitoring.TotalAcquisitions - cachedTotalAcquisitions;
+							var missedAcquisitions = bridge.Monitoring.DroppedAcquisitions - cachedMissedAcquisitions;
+							var uiUpdates = totalAcquisitions - missedAcquisitions;
 
-                            //logger.LogDebug($"Outstanding frames: {processChannel.PeekAvailable()}, dequeues/sec: {dequeueCount / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, dequeue count: {totalDequeueCount}");
-                            logger.LogDebug($"Bridge writes/sec: {totalAcquisitions / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, Bridge reads/sec: {uiUpdates / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, total: {bridge.Monitoring.TotalAcquisitions}, dropped: {bridge.Monitoring.DroppedAcquisitions}");
-                            periodicUpdateTimer.Restart();
+							//logger.LogDebug($"Outstanding frames: {processChannel.PeekAvailable()}, dequeues/sec: {dequeueCount / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, dequeue count: {totalDequeueCount}");
+							logger.LogDebug($"Bridge writes/sec: {totalAcquisitions / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, Bridge reads/sec: {uiUpdates / periodicUpdateTimer.Elapsed.TotalSeconds:F2}, total: {bridge.Monitoring.TotalAcquisitions}, dropped: {bridge.Monitoring.DroppedAcquisitions}");
+							periodicUpdateTimer.Restart();
 
-                            cachedTotalDequeueCount = totalDequeueCount;
-                            cachedTotalAcquisitions = bridge.Monitoring.TotalAcquisitions;
-                            cachedMissedAcquisitions = bridge.Monitoring.DroppedAcquisitions;
-                        }
-                    }
-                }
+							cachedTotalDequeueCount = totalDequeueCount;
+							cachedTotalAcquisitions = bridge.Monitoring.TotalAcquisitions;
+							cachedMissedAcquisitions = bridge.Monitoring.DroppedAcquisitions;
+						}
+					}
+				}
 
-                // Locally scoped methods for deduplication
-                void UpdateTriggerHorizontalPosition()
-                {
-                    ulong femtosecondsPerSample = cachedHardwareConfig.AdcChannelMode switch
-                    {
-                        AdcChannelMode.Single => 1000000,         // 1 GSPS
-                        AdcChannelMode.Dual => 1000000 * 2,     // 500 MSPS
-                        AdcChannelMode.Quad => 1000000 * 4,    // 250 MSPS
-                        _ => throw new NotImplementedException(),
-                    };
+				// Locally scoped methods for deduplication
+				void UpdateTriggerHorizontalPosition()
+				{
+					ulong femtosecondsPerSample = cachedHardwareConfig.AdcChannelMode switch
+					{
+						AdcChannelMode.Single => 1000000,         // 1 GSPS
+						AdcChannelMode.Dual => 1000000 * 2,     // 500 MSPS
+						AdcChannelMode.Quad => 1000000 * 4,    // 250 MSPS
+						_ => throw new NotImplementedException(),
+					};
 
-                    var windowTriggerPosition = processingConfig.TriggerDelayFs / femtosecondsPerSample;
-                    risingEdgeTrigger.SetHorizontal(processingConfig.CurrentChannelDataLength, windowTriggerPosition, processingConfig.TriggerHoldoff);
-                    fallingEdgeTrigger.SetHorizontal(processingConfig.CurrentChannelDataLength, windowTriggerPosition, processingConfig.TriggerHoldoff);
-                }
+					var windowTriggerPosition = processingConfig.TriggerDelayFs / femtosecondsPerSample;
+					risingEdgeTrigger.SetHorizontal(processingConfig.CurrentChannelDataLength, windowTriggerPosition, processingConfig.TriggerHoldoff);
+					fallingEdgeTrigger.SetHorizontal(processingConfig.CurrentChannelDataLength, windowTriggerPosition, processingConfig.TriggerHoldoff);
+				}
 
-                void SingleChannelStream(int channelLength)
-                {
-                    while (streamSampleCounter > channelLength)
-                    {
-                        streamSampleCounter -= channelLength;
-                        var bridgeSpan = bridge.AcquiringRegionI8;
-                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
-                        bridge.DataWritten();
-                        bridge.SwitchRegionIfNeeded();
-                    }
-                }
+				void SingleChannelStream(int channelLength)
+				{
+					while (streamSampleCounter > channelLength)
+					{
+						streamSampleCounter -= channelLength;
+						var bridgeSpan = bridge.AcquiringRegionI8;
+						circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
+						bridge.DataWritten();
+						bridge.SwitchRegionIfNeeded();
+					}
+				}
 
-                void DualChannelStream(int channelLength)
-                {
-                    while (streamSampleCounter > channelLength)
-                    {
-                        streamSampleCounter -= channelLength;
-                        var bridgeSpan = bridge.AcquiringRegionI8;
-                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
-                        circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
-                        bridge.DataWritten();
-                        bridge.SwitchRegionIfNeeded();
-                    }
-                }
+				void DualChannelStream(int channelLength)
+				{
+					while (streamSampleCounter > channelLength)
+					{
+						streamSampleCounter -= channelLength;
+						var bridgeSpan = bridge.AcquiringRegionI8;
+						circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
+						circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
+						bridge.DataWritten();
+						bridge.SwitchRegionIfNeeded();
+					}
+				}
 
-                void QuadChannelStream(int channelLength)
-                {
-                    while (streamSampleCounter > channelLength)
-                    {
-                        streamSampleCounter -= channelLength;
-                        var bridgeSpan = bridge.AcquiringRegionI8;
-                        circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
-                        circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
-                        circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), 0);
-                        circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), 0);
-                        bridge.DataWritten();
-                        bridge.SwitchRegionIfNeeded();
-                    }
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                logger.LogDebug("Stopping...");
-            }
-            catch (Exception ex)
-            {
-                logger.LogCritical(ex, "Error");
-                throw;
-            }
-            finally
-            {
-                logger.LogDebug("Stopped");
-            }
-        }
-    }
+				void QuadChannelStream(int channelLength)
+				{
+					while (streamSampleCounter > channelLength)
+					{
+						streamSampleCounter -= channelLength;
+						var bridgeSpan = bridge.AcquiringRegionI8;
+						circularBuffer1.Read(bridgeSpan.Slice(0, channelLength), 0);        // TODO - work out if this should be zero?
+						circularBuffer2.Read(bridgeSpan.Slice(channelLength, channelLength), 0);
+						circularBuffer3.Read(bridgeSpan.Slice(channelLength + channelLength, channelLength), 0);
+						circularBuffer4.Read(bridgeSpan.Slice(channelLength + channelLength + channelLength, channelLength), 0);
+						bridge.DataWritten();
+						bridge.SwitchRegionIfNeeded();
+					}
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				logger.LogDebug("Stopping...");
+			}
+			catch (Exception ex)
+			{
+				logger.LogCritical(ex, "Error");
+				throw;
+			}
+			finally
+			{
+				logger.LogDebug("Stopped");
+			}
+		}
+	}
 }

--- a/source/TS.NET/Drivers/XMDA/Thunderscope.cs
+++ b/source/TS.NET/Drivers/XMDA/Thunderscope.cs
@@ -1,698 +1,710 @@
-﻿#define TsRev4
-// Define options: TsRev1, TsRev3, TsRev4
-
-using System.Buffers.Binary;
+﻿using System.Buffers.Binary;
 using TS.NET.Driver.XMDA.Interop;
 
 namespace TS.NET.Driver.XMDA
 {
-    public record ThunderscopeDevice(string DevicePath);
-
-    public class Thunderscope : IThunderscope
-    {
-        private ThunderscopeInterop interop;
-        private ThunderscopeCalibration calibration;
-        private bool open = false;
-        private ThunderscopeHardwareState hardwareState;
-        private ThunderscopeHardwareConfig configuration;
-
-        public Thunderscope()
-        {
-            hardwareState = new();
-            configuration = new()
-            {
-                AdcChannelMode = AdcChannelMode.Quad,
-                EnabledChannels = 0b00001111
-            };
-            configuration.Channels[0] = ThunderscopeChannel.Default();
-            configuration.Channels[1] = ThunderscopeChannel.Default();
-            configuration.Channels[2] = ThunderscopeChannel.Default();
-            configuration.Channels[3] = ThunderscopeChannel.Default();
-        }
-
-        public static List<ThunderscopeDevice> IterateDevices()
-        {
-            return ThunderscopeInterop.IterateDevices();
-        }
-
-        public void Open(ThunderscopeDevice device, ThunderscopeCalibration calibration)
-        {
-            if (open)
-                Close();
-
-            interop = ThunderscopeInterop.CreateInterop(device);
-            this.calibration = calibration;
-
-            Initialise();
-            open = true;
-        }
-
-        public void Close()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            open = false;
-        }
-
-        public void Start()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (hardwareState.DatamoverEnabled)
-                throw new Exception("Thunderscope already started");
-            hardwareState.DatamoverEnabled = true;
-            hardwareState.FpgaAdcEnabled = true;
-            hardwareState.BufferHead = 0;
-            hardwareState.BufferTail = 0;
-            ConfigureDatamover(hardwareState);
-        }
-
-        public void Stop()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (!hardwareState.DatamoverEnabled)
-                throw new Exception("Thunderscope not started");
-            hardwareState.DatamoverEnabled = false;
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(5);
-            hardwareState.FpgaAdcEnabled = false;
-            ConfigureDatamover(hardwareState);
-        }
-
-        public void Read(ThunderscopeMemory data, CancellationToken cancellationToken)     //ThunderscopeMemory ensures memory is aligned on 4k boundary
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (!hardwareState.DatamoverEnabled)
-                throw new ThunderscopeNotRunningException("Thunderscope not started");
-
-            // Buffer data must be aligned to 4096
-            //if (0xFFF & (ptrdiff_t)data)
-            //{
-            //    throw new Exception("data not aligned to 4096 boundary");
-            //}
-
-            ulong length = ThunderscopeMemory.Length;
-            // Align length to 4096.
-            //length &= ~0xFFFUL;
-
-            UpdateBufferHead();
-
-            ulong dataIndex = 0;
-            while (length > 0)
-            {
-                ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
-                if (pages_available == 0)
-                {
-
-                    //Thread.Sleep(1);
-                    //Thread.Yield();
-                    Thread.SpinWait(1000);
-                    UpdateBufferHead();
-                    continue;
-                }
-                ulong pages_to_read = length >> 12;
-                if (pages_to_read > pages_available) pages_to_read = pages_available;
-                ulong buffer_read_pos = hardwareState.BufferTail % hardwareState.RamSizePages;
-                if (pages_to_read > hardwareState.RamSizePages - buffer_read_pos) pages_to_read = hardwareState.RamSizePages - buffer_read_pos;
-                if (pages_to_read > hardwareState.RamSizePages / 4) pages_to_read = hardwareState.RamSizePages / 4;
-
-                interop.ReadC2H(data, dataIndex, buffer_read_pos << 12, pages_to_read << 12);
-                //read_handle(ts, ts->c2h0_handle, dataPtr, buffer_read_pos << 12, pages_to_read << 12);
-
-                dataIndex += pages_to_read << 12;
-                length -= pages_to_read << 12;
-
-                // Update buffer head and calculate overflow BEFORE
-                // updating buffer tail as it is possible
-                // that a buffer overflow occured while we were reading.
-                UpdateBufferHead();
-                hardwareState.BufferTail += pages_to_read;
-            }
-        }
-
-        // Returns a by-value copy
-        public ThunderscopeChannel GetChannel(int channelIndex)
-        {
-            return configuration.Channels[channelIndex];
-        }
-
-        public void SetChannel(int channelIndex, ThunderscopeChannel channel)
-        {
-            CalculateAfeConfiguration(ref channel);
-            configuration.Channels[channelIndex] = channel;
-            UpdateAdc();
-            Thread.Sleep(10);      // This delay is essential for ensuring channel 1 value gets set (the assumption is that the FIFO isn't ready immediately)
-            SetDAC(channelIndex);
-            Thread.Sleep(10);      // Don't know if this delay is needed, added for belt'n'braces
-            SetPGA(channelIndex);
-        }
-
-        public void SetChannelEnable(int channelIndex, bool enabled)
-        {
-            if (enabled)
-            {
-                configuration.EnabledChannels |= (byte)(0x01 << channelIndex);
-            }
-            else
-            {
-                configuration.EnabledChannels &= (byte)~(0x01 << channelIndex);
-            }
-        }
-
-        // Returns a by-value copy
-        public ThunderscopeHardwareConfig GetConfiguration()
-        {
-            return configuration;
-        }
-
-        public void ResetBuffer()
-        {
-            hardwareState.BufferHead = 0;
-            hardwareState.BufferTail = 0;
-            ConfigureDatamover(hardwareState);
-        }
-
-        private void Initialise()
-        {
-            CalculateAfeConfiguration(ref configuration.Channels[0]);
-            CalculateAfeConfiguration(ref configuration.Channels[1]);
-            CalculateAfeConfiguration(ref configuration.Channels[2]);
-            CalculateAfeConfiguration(ref configuration.Channels[3]);
-
-            Write32(BarRegister.DATAMOVER_REG_OUT, 0);
-
-            //Comment out below for Rev.1
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-            //Comment out above for Rev.1
-
-            hardwareState.BoardEnabled = true;
-            ConfigureDatamover(hardwareState);
-            ConfigurePLL();
-            ConfigureAdc();
-
-            UpdateAdc();
-
-            for (int i = 0; i < 4; i++)
-            {
-                Thread.Sleep(10);      // This delay is essential for ensuring channel 1 value gets set (the assumption is that the FIFO isn't ready immediately)
-                SetDAC(i);
-                Thread.Sleep(10);      // Don't know if this delay is needed, added for belt'n'braces
-                SetPGA(i);
-            }
-        }
-
-        private uint Read32(BarRegister register)
-        {
-            Span<byte> bytes = new byte[4];
-            interop.ReadUser(bytes, (ulong)register);
-            return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
-        }
-
-        private void Write32(BarRegister register, uint value)
-        {
-            Span<byte> bytes = new byte[4];
-            BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
-            interop.WriteUser(bytes, (ulong)register);
-        }
-
-        private void WriteFifo(ReadOnlySpan<byte> data)
-        {
-            // reset ISR
-            Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
-            // read ISR and IER
-            Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS);
-            Read32(BarRegister.SERIAL_FIFO_IER_ADDRESS);
-            // enable IER
-            Write32(BarRegister.SERIAL_FIFO_IER_ADDRESS, 0x0C000000U);
-            // Set false TDR
-            Write32(BarRegister.SERIAL_FIFO_TDR_ADDRESS, 0x2U);
-            // Put data into queue
-            for (int i = 0; i < data.Length; i++)
-            {
-                //interop.WriteUser(data.Slice(i, 1), (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
-                Span<byte> bytes = new byte[4];
-                bytes.Fill(data[i]);
-                interop.WriteUser(bytes, (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
-            }
-            // read TDFV (vacancy byte)
-            Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
-            // write to TLR (the size of the packet)
-            Write32(BarRegister.SERIAL_FIFO_TLR_ADDRESS, (uint)(data.Length * 4));
-            // read ISR for a done value
-            while (Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS) >> 24 != 8)
-            {
-                Thread.Sleep(1);
-            }
-            // reset ISR
-            Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
-            // read TDFV
-            Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
-        }
-
-        private void ConfigureDatamover(ThunderscopeHardwareState state)
-        {
-            uint datamoverRegister = 0;
-            if (state.BoardEnabled) datamoverRegister |= 0x01000000;
-            if (state.PllEnabled) datamoverRegister |= 0x02000000;
-            if (state.FrontEndEnabled) datamoverRegister |= 0x04000000;
-            if (state.DatamoverEnabled) datamoverRegister |= 0x1;
-            if (state.FpgaAdcEnabled) datamoverRegister |= 0x2;
-
-            int numChannelsEnabled = 0;
-            for (int channel = 0; channel < 4; channel++)
-            {
-                if (((configuration.EnabledChannels >> channel) & 0x01) > 0)
-                {
-                    numChannelsEnabled++;
-                }
-                if (configuration.Channels[channel].Termination == ThunderscopeTermination.FiftyOhm)
-                {
-                    datamoverRegister |= (uint)1 << (12 + channel);
-                }
-                if (!configuration.Channels[channel].Attenuator)
-                {
-                    datamoverRegister |= (uint)1 << 16 + channel;
-                }
-                if (configuration.Channels[channel].Coupling == ThunderscopeCoupling.DC)
-                {
-                    datamoverRegister |= (uint)1 << 20 + channel;
-                }
-            }
-            switch (numChannelsEnabled)
-            {
-                case 0:
-                case 1: break; // do nothing
-                case 2: datamoverRegister |= 0x10; break;
-                default: datamoverRegister |= 0x30; break;
-            }
-            Write32(BarRegister.DATAMOVER_REG_OUT, datamoverRegister);
-        }
-
-        private void ConfigureAdc()
-        {
-            // Reset ADC
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RESET, 0x0001);
-            // Power Down ADC
-            AdcPower(false);
-            // Invert channels
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INVERT, 0x007F);
-            // Adjust full scale value
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_FS_CNTRL, 0x0010);
-            // Course Gain On
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_GAIN_CFG, 0x0000);
-            // Course Gain 4-CH set
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_QUAD_GAIN, 0x9999);
-            // Course Gain 1-CH & 2-CH set
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_DUAL_GAIN, 0x0A99);
-            //Set adc into active mode
-            //currentBoardState.num_ch_on++;
-            //currentBoardState.ch_is_on[0] = true;
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_chnum_clkdiv,sizeof(currentBoardState.adc_chnum_clkdiv));
-
-            // Set 8-bit mode (for HMCAD1520, won't do anything for HMCAD1511)
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RES_SEL, 0x0000);
-
-            //Set LVDS phase to 0 Deg & Drive Strength to RSDS
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_PHASE, 0x0060);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_DRIVE, 0x0222);
-
-            AdcPower(true);
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_12,sizeof(currentBoardState.adc_in_sel_12));
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_34,sizeof(currentBoardState.adc_in_sel_34));
-
-            hardwareState.FrontEndEnabled = true;
-            ConfigureDatamover(hardwareState);
-        }
-
-        const byte SPI_BYTE_ADC = 0xFD;
-        private void SetAdcRegister(AdcRegister register, ushort value)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = SPI_BYTE_ADC;
-            fifo[1] = (byte)register;
-            fifo[2] = (byte)(value >> 8);
-            fifo[3] = (byte)(value & 0xff);
-            WriteFifo(fifo);
-        }
-
-        private void AdcPower(bool on)
-        {
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_POWER, (ushort)(on ? 0x0000 : 0x0200));
-        }
-
-        private void UpdateAdc()
-        {
-            byte[] on_channels = new byte[4];
-            int num_channels_on = 0;
-            for (int i = 0; i < 4; i++)
-            {
-                if (((configuration.EnabledChannels >> i) & 0x01) > 0)
-                {
-                    on_channels[num_channels_on++] = (byte)(3 - i);
-                }
-            }
-
-            byte clkdiv;
-            switch (num_channels_on)
-            {
-                case 0:
-                case 1:
-                    on_channels[3] = on_channels[2] = on_channels[1] = on_channels[0];
-                    clkdiv = 0;
-                    configuration.AdcChannelMode = AdcChannelMode.Single;
-                    break;
-                case 2:
-                    on_channels[2] = on_channels[3] = on_channels[1];
-                    on_channels[1] = on_channels[0];
-                    clkdiv = 1;
-                    configuration.AdcChannelMode = AdcChannelMode.Dual;
-                    break;
-                default:
-                    on_channels[0] = 3;
-                    on_channels[1] = 2;
-                    on_channels[2] = 1;
-                    on_channels[3] = 0;
-                    num_channels_on = 4;
-                    clkdiv = 2;
-                    configuration.AdcChannelMode = AdcChannelMode.Quad;
-                    break;
-            }
-
-            AdcPower(false);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_CHNUM_CLKDIV, (ushort)(clkdiv << 8 | num_channels_on));
-            AdcPower(true);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL12, (ushort)(2 << on_channels[0] | 512 << on_channels[1]));
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL34, (ushort)(2 << on_channels[2] | 512 << on_channels[3]));
-
-            ThunderscopeHardwareState temporaryState = hardwareState;
-            temporaryState.DatamoverEnabled = false;
-            temporaryState.FpgaAdcEnabled = false;
-            ConfigureDatamover(temporaryState);
-
-            Thread.Sleep(5);
-
-            if (num_channels_on != 0)
-                ConfigureDatamover(hardwareState);
-        }
-
-        private void SetDAC(int channel)
-        {
-            // value is 12-bit
-            // Is this right?? Or is it rounding wrong?
-            //uint dac_value = (uint)Math.Round((configuration.GetChannel(channel).VoltOffset + 0.5) * 4095);
-
-            ushort dacValue = channel switch
-            {
-                0 => calibration.Channel1.TrimOffsetDac,
-                1 => calibration.Channel2.TrimOffsetDac,
-                2 => calibration.Channel3.TrimOffsetDac,
-                3 => calibration.Channel4.TrimOffsetDac,
-            };
-            if (dacValue < 0)
-                throw new Exception("DAC offset too low");
-            if (dacValue > 0xFFF)
-                throw new Exception("DAC offset too high");
-
-            Span<byte> fifo = new byte[5];
-            fifo[0] = 0xFF;  // I2C
-            fifo[1] = 0xC0;  // DAC? New address is C0 since part is A0 variant
-            //fifo[2] = (byte)(0x40 + (channelIndex << 1));
-            fifo[2] = (byte)(0x58 + (channel << 1));       // p41 of MCP4728 datasheet
-            fifo[3] = (byte)(dacValue >> 8 & 0xF);     // Vref = VDD. Power down = normal mode. Gain = 1
-            fifo[4] = (byte)(dacValue & 0xFF);
-            WriteFifo(fifo);
-        }
-
-        private void SetPGA(int channel)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = (byte)(0xFB - channel);  // SPI chip enable
-            fifo[1] = 0;
-            fifo[2] = 0x04;  // ??
-            fifo[3] = configuration.Channels[channel].PgaConfigurationByte;
-            switch (configuration.Channels[channel].Bandwidth)
-            {
-                case 20: fifo[3] |= 0x40; break;
-                case 100: fifo[3] |= 0x80; break;
-                case 200: fifo[3] |= 0xC0; break;
-                case 350: /* 0 */ break;
-                default: throw new Exception("Invalid bandwidth");
-            }
-            WriteFifo(fifo);
-        }
-
-        private void UpdateBufferHead()
-        {
-            // 1 page = 4k
-            uint transfer_counter = Read32(BarRegister.DATAMOVER_TRANSFER_COUNTER);
-            uint error_code = transfer_counter >> 30;
-            if ((error_code & 2) > 0)
-                throw new Exception("Thunderscope - datamover error");
-
-            if ((error_code & 1) > 0)
-                throw new ThunderscopeFifoOverflowException("Thunderscope - FIFO overflow");
-
-            uint overflow_cycles = transfer_counter >> 16 & 0x3FFF;
-            if (overflow_cycles > 0)
-                throw new Exception("Thunderscope - pipeline overflow");
-
-            uint pages_moved = transfer_counter & 0xFFFF;
-            ulong buffer_head = hardwareState.BufferHead & ~0xFFFFUL | pages_moved;
-            if (buffer_head < hardwareState.BufferHead)
-                buffer_head += 0x10000UL;
-
-            hardwareState.BufferHead = buffer_head;
-
-            ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
-            if (pages_available >= hardwareState.RamSizePages)
-                throw new ThunderscopeMemoryOutOfMemoryException("Thunderscope - memory full");
-        }
-
-        // Channel passed by ref to do in-place updating
-        // Returns PGA configuration byte
-        public static void CalculateAfeConfiguration(ref ThunderscopeChannel channel)
-        {
-            double requestedVoltFullScale = channel.VoltFullScale;
-            double attenuatorFactor = 1.0 / 50.0;
-            double headroomFactor = 1.0;        // Buf802 has 0.961 so can get away with setting this to 1.0 instead of something like 0.95
-            double adcFullScaleRange = 0.7;     // Vpp
-            double adcFullScaleRangeWithHeadroom = headroomFactor * adcFullScaleRange;
-            // Remember the minimum PGA LNA gain is 10dB, that's a factor of 3.162 which might hit a PGA voltage rail internally before it has a chance to be attenuated...
-            // So might need to change this attenuatorThreasholdVolts calculation
-            double attenuatorThresholdVolts = adcFullScaleRangeWithHeadroom / Math.Pow(10, -1.14 / 20.0);   // -1.14dB is the minimum possible PGA gain however the PGA gain chain is 10dB + -20dB + 8.86dB, so be cautious.
-
-            // Check attenuator threshold and set afeAttenuatorEnabled if needed
-            channel.Attenuator = false;
-            if (requestedVoltFullScale > attenuatorThresholdVolts)
-            {
-                channel.Attenuator = true;
-                requestedVoltFullScale *= attenuatorFactor;
-            }
-
-            // Calculate the ideal PGA gain before searching the possible PGA gains (where possible range is -1.14dB to 38.8dB in 2dB steps)
-            double requestedPgaGainDb = 20 * Math.Log10(adcFullScaleRangeWithHeadroom / requestedVoltFullScale);
-
-            // Now check all the PGA gain options, starting from highest gain setting
-            bool gainFound = false;
-            bool lnaHighGain = true;
-            int n;
-            double pgaGainCalculation() { return (lnaHighGain ? 30 : 10) - 2 * n + 8.86; }
-            for (n = 0; n < 10; n++)
-            {
-                var potentialPgaGainDb = pgaGainCalculation();
-                if (potentialPgaGainDb < requestedPgaGainDb)
-                {
-                    gainFound = true;
-                    break;
-                }
-            }
-            if (!gainFound)
-            {
-                lnaHighGain = false;
-                for (n = 0; n <= 10; n++)
-                {
-                    var potentialPgaGainDb = pgaGainCalculation();
-                    if (potentialPgaGainDb < requestedPgaGainDb)
-                    {
-                        gainFound = true;
-                        break;
-                    }
-                }
-            }
-            if (!gainFound)
-                throw new NotSupportedException();
-
-            var actualPgaGainDb = pgaGainCalculation();
-            channel.ActualVoltFullScale = adcFullScaleRangeWithHeadroom / Math.Pow(10, actualPgaGainDb / 20);
-            if (channel.Attenuator)
-                channel.ActualVoltFullScale /= attenuatorFactor;
-
-            // Decode N into PGA LNA gain and PGA attentuator step
-            channel.PgaConfigurationByte = (byte)n;
-            if (lnaHighGain)
-                channel.PgaConfigurationByte |= 0x10;
-
-            // fifo[3] register
-            // [PGA LPF][PGA LPF][PGA LPF][PGA LNA gain][PGA attenuator][PGA attenuator][PGA attenuator][PGA attenuator]
-
-            // case 100: fifo[3] = 0x0A; break;
-            // case 50: fifo[3] = 0x07; break;
-            // case 20: fifo[3] = 0x03; break;
-            // case 10: fifo[3] = 0x1A; break;
-            // case 5: fifo[3] = 0x17; break;
-            // case 2: fifo[3] = 0x13; break;
-            // case 1: fifo[3] = 0x10; break;
-
-            // https://www.ti.com/lit/ds/symlink/lmh6518.pdf page 22
-            // case 20: fifo[3] |= 0x40; break;
-            // case 100: fifo[3] |= 0x80; break;
-            // case 200: fifo[3] |= 0xC0; break;
-            // case 350: /* 0 */ break;
-        }
-#if TsRev1
-        private void ConfigurePLL()
-        {
-            // These were provided by the chip configuration tool.
-            ushort[] config_clk_gen = {
-                0x0010, 0x010B, 0x0233, 0x08B0,
-                0x0901, 0x1000, 0x1180, 0x1501,
-                0x1600, 0x1705, 0x1900, 0x1A32,
-                0x1B00, 0x1C00, 0x1D00, 0x1E00,
-                0x1F00, 0x2001, 0x210C, 0x2228,
-                0x2303, 0x2408, 0x2500, 0x2600,
-                0x2700, 0x2F00, 0x3000, 0x3110,
-                0x3200, 0x3300, 0x3400, 0x3500,
-                0x3800, 0x4802 };
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length / 2; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            hardwareState.PllEnabled = true;
-            ConfigureDatamover(hardwareState);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b10110000;
-        private void SetPllRegister(byte register, byte value)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = register;
-            fifo[3] = value;
-            WriteFifo(fifo);
-        }
-#endif
-
-#if TsRev3
-        private void ConfigurePLL()
-        {
-            //Strobe RST line on power on
-            Thread.Sleep(1);
-            hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-
-            // These were provided by the chip configuration tool.
-            uint[] config_clk_gen = {
-                0X000902, 0X062108, 0X063140, 0X010006,
-                0X010120, 0X010202, 0X010380, 0X010A20,
-                0X010B03, 0X01140D, 0X012006, 0X0125C0,
-                0X012660, 0X01277F, 0X012904, 0X012AB3,
-                0X012BC0, 0X012C80, 0X001C10, 0X001D80,
-                0X034003, 0X020141, 0X022135, 0X022240,
-                0X000C02, 0X000B01};
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            Thread.Sleep(10);
-
-            SetPllRegister(0x00, 0x0D, 0x05);
-
-            Thread.Sleep(10);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b11011000;
-        const byte CLOCK_GEN_WRITE_COMMAND = 0x02;
-        private void SetPllRegister(byte reg_high, byte reg_low, byte value)
-        {
-            Span<byte> fifo = new byte[6];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = CLOCK_GEN_WRITE_COMMAND;
-            fifo[3] = reg_high;
-            fifo[4] = reg_low;
-            fifo[5] = value;
-            WriteFifo(fifo);
-        }
-#endif
-
-#if TsRev4
-        private void ConfigurePLL()
-        {
-            //Strobe RST line on power on
-            Thread.Sleep(10);
-            hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(10);
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(10);
-
-            // These were provided by the chip configuration tool.
-            uint[] config_clk_gen = {
-                0x042308, 0x000301, 0x000402, 0x000521,
-                0x000701, 0x010042, 0x010100, 0x010201,
-                0x010600, 0x010700, 0x010800, 0x010900,
-                0x010A20, 0x010B03, 0x012160, 0x012790,
-                0x014100, 0x014200, 0x014300, 0x014400,
-                0x0145A0, 0x015300, 0x015450, 0x0155CE,
-                0x018000, 0x020080, 0x020105, 0x025080,
-                0x025102, 0x04300C, 0x043000};
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            Thread.Sleep(10);
-
-            SetPllRegister((byte)(0x01), (byte)(0x00), (byte)(0x02)); //0x010002
-            SetPllRegister((byte)(0x01), (byte)(0x00), (byte)(0x42)); //0x010042
-
-            Thread.Sleep(10);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b11101000;
-        const byte CLOCK_GEN_WRITE_COMMAND = 0x02;
-        private void SetPllRegister(byte reg_high, byte reg_low, byte value)
-        {
-            Span<byte> fifo = new byte[6];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = CLOCK_GEN_WRITE_COMMAND;
-            fifo[3] = reg_high;
-            fifo[4] = reg_low;
-            fifo[5] = value;
-            WriteFifo(fifo);
-        }
-#endif
-    }
+	public record ThunderscopeDevice(string DevicePath);
+
+	public class Thunderscope : IThunderscope
+	{
+		private ThunderscopeInterop interop;
+		private ThunderscopeCalibration calibration;
+		private bool open = false;
+		private ThunderscopeHardwareState hardwareState;
+		private ThunderscopeHardwareConfig configuration;
+		private int revision;
+
+		public Thunderscope()
+		{
+			hardwareState = new();
+			configuration = new()
+			{
+				AdcChannelMode = AdcChannelMode.Quad,
+				EnabledChannels = 0b00001111
+			};
+			configuration.Channels[0] = ThunderscopeChannel.Default();
+			configuration.Channels[1] = ThunderscopeChannel.Default();
+			configuration.Channels[2] = ThunderscopeChannel.Default();
+			configuration.Channels[3] = ThunderscopeChannel.Default();
+		}
+
+		public static List<ThunderscopeDevice> IterateDevices()
+		{
+			return ThunderscopeInterop.IterateDevices();
+		}
+
+		public void Open(ThunderscopeDevice device, ThunderscopeCalibration calibration, int revision = 4)
+		{
+			if (open)
+				Close();
+
+			interop = ThunderscopeInterop.CreateInterop(device);
+			this.calibration = calibration;
+			this.revision = revision;
+
+			Initialise();
+			open = true;
+		}
+
+		public void Close()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			open = false;
+		}
+
+		public void Start()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (hardwareState.DatamoverEnabled)
+				throw new Exception("Thunderscope already started");
+			hardwareState.DatamoverEnabled = true;
+			hardwareState.FpgaAdcEnabled = true;
+			hardwareState.BufferHead = 0;
+			hardwareState.BufferTail = 0;
+			ConfigureDatamover(hardwareState);
+		}
+
+		public void Stop()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (!hardwareState.DatamoverEnabled)
+				throw new Exception("Thunderscope not started");
+			hardwareState.DatamoverEnabled = false;
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(5);
+			hardwareState.FpgaAdcEnabled = false;
+			ConfigureDatamover(hardwareState);
+		}
+
+		public void Read(ThunderscopeMemory data, CancellationToken cancellationToken)     //ThunderscopeMemory ensures memory is aligned on 4k boundary
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (!hardwareState.DatamoverEnabled)
+				throw new ThunderscopeNotRunningException("Thunderscope not started");
+
+			// Buffer data must be aligned to 4096
+			//if (0xFFF & (ptrdiff_t)data)
+			//{
+			//    throw new Exception("data not aligned to 4096 boundary");
+			//}
+
+			ulong length = ThunderscopeMemory.Length;
+			// Align length to 4096.
+			//length &= ~0xFFFUL;
+
+			UpdateBufferHead();
+
+			ulong dataIndex = 0;
+			while (length > 0)
+			{
+				ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
+				if (pages_available == 0)
+				{
+
+					//Thread.Sleep(1);
+					//Thread.Yield();
+					Thread.SpinWait(1000);
+					UpdateBufferHead();
+					continue;
+				}
+				ulong pages_to_read = length >> 12;
+				if (pages_to_read > pages_available) pages_to_read = pages_available;
+				ulong buffer_read_pos = hardwareState.BufferTail % hardwareState.RamSizePages;
+				if (pages_to_read > hardwareState.RamSizePages - buffer_read_pos) pages_to_read = hardwareState.RamSizePages - buffer_read_pos;
+				if (pages_to_read > hardwareState.RamSizePages / 4) pages_to_read = hardwareState.RamSizePages / 4;
+
+				interop.ReadC2H(data, dataIndex, buffer_read_pos << 12, pages_to_read << 12);
+				//read_handle(ts, ts->c2h0_handle, dataPtr, buffer_read_pos << 12, pages_to_read << 12);
+
+				dataIndex += pages_to_read << 12;
+				length -= pages_to_read << 12;
+
+				// Update buffer head and calculate overflow BEFORE
+				// updating buffer tail as it is possible
+				// that a buffer overflow occured while we were reading.
+				UpdateBufferHead();
+				hardwareState.BufferTail += pages_to_read;
+			}
+		}
+
+		// Returns a by-value copy
+		public ThunderscopeChannel GetChannel(int channelIndex)
+		{
+			return configuration.Channels[channelIndex];
+		}
+
+		public void SetChannel(int channelIndex, ThunderscopeChannel channel)
+		{
+			CalculateAfeConfiguration(ref channel);
+			configuration.Channels[channelIndex] = channel;
+			UpdateAdc();
+			Thread.Sleep(10);      // This delay is essential for ensuring channel 1 value gets set (the assumption is that the FIFO isn't ready immediately)
+			SetDAC(channelIndex);
+			Thread.Sleep(10);      // Don't know if this delay is needed, added for belt'n'braces
+			SetPGA(channelIndex);
+		}
+
+		public void SetChannelEnable(int channelIndex, bool enabled)
+		{
+			if (enabled)
+			{
+				configuration.EnabledChannels |= (byte)(0x01 << channelIndex);
+			}
+			else
+			{
+				configuration.EnabledChannels &= (byte)~(0x01 << channelIndex);
+			}
+		}
+
+		// Returns a by-value copy
+		public ThunderscopeHardwareConfig GetConfiguration()
+		{
+			return configuration;
+		}
+
+		public void ResetBuffer()
+		{
+			hardwareState.BufferHead = 0;
+			hardwareState.BufferTail = 0;
+			ConfigureDatamover(hardwareState);
+		}
+
+		private void Initialise()
+		{
+			CalculateAfeConfiguration(ref configuration.Channels[0]);
+			CalculateAfeConfiguration(ref configuration.Channels[1]);
+			CalculateAfeConfiguration(ref configuration.Channels[2]);
+			CalculateAfeConfiguration(ref configuration.Channels[3]);
+
+			Write32(BarRegister.DATAMOVER_REG_OUT, 0);
+
+			//Comment out below for Rev.1
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+			//Comment out above for Rev.1
+
+			hardwareState.BoardEnabled = true;
+			ConfigureDatamover(hardwareState);
+			ConfigurePLL();
+			ConfigureAdc();
+
+			UpdateAdc();
+
+			for (int i = 0; i < 4; i++)
+			{
+				Thread.Sleep(10);      // This delay is essential for ensuring channel 1 value gets set (the assumption is that the FIFO isn't ready immediately)
+				SetDAC(i);
+				Thread.Sleep(10);      // Don't know if this delay is needed, added for belt'n'braces
+				SetPGA(i);
+			}
+		}
+
+		private uint Read32(BarRegister register)
+		{
+			Span<byte> bytes = new byte[4];
+			interop.ReadUser(bytes, (ulong)register);
+			return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+		}
+
+		private void Write32(BarRegister register, uint value)
+		{
+			Span<byte> bytes = new byte[4];
+			BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+			interop.WriteUser(bytes, (ulong)register);
+		}
+
+		private void WriteFifo(ReadOnlySpan<byte> data)
+		{
+			// reset ISR
+			Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
+			// read ISR and IER
+			Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS);
+			Read32(BarRegister.SERIAL_FIFO_IER_ADDRESS);
+			// enable IER
+			Write32(BarRegister.SERIAL_FIFO_IER_ADDRESS, 0x0C000000U);
+			// Set false TDR
+			Write32(BarRegister.SERIAL_FIFO_TDR_ADDRESS, 0x2U);
+			// Put data into queue
+			for (int i = 0; i < data.Length; i++)
+			{
+				//interop.WriteUser(data.Slice(i, 1), (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
+				Span<byte> bytes = new byte[4];
+				bytes.Fill(data[i]);
+				interop.WriteUser(bytes, (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
+			}
+			// read TDFV (vacancy byte)
+			Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
+			// write to TLR (the size of the packet)
+			Write32(BarRegister.SERIAL_FIFO_TLR_ADDRESS, (uint)(data.Length * 4));
+			// read ISR for a done value
+			while (Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS) >> 24 != 8)
+			{
+				Thread.Sleep(1);
+			}
+			// reset ISR
+			Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
+			// read TDFV
+			Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
+		}
+
+		private void ConfigureDatamover(ThunderscopeHardwareState state)
+		{
+			uint datamoverRegister = 0;
+			if (state.BoardEnabled) datamoverRegister |= 0x01000000;
+			if (state.PllEnabled) datamoverRegister |= 0x02000000;
+			if (state.FrontEndEnabled) datamoverRegister |= 0x04000000;
+			if (state.DatamoverEnabled) datamoverRegister |= 0x1;
+			if (state.FpgaAdcEnabled) datamoverRegister |= 0x2;
+
+			int numChannelsEnabled = 0;
+			for (int channel = 0; channel < 4; channel++)
+			{
+				if (((configuration.EnabledChannels >> channel) & 0x01) > 0)
+				{
+					numChannelsEnabled++;
+				}
+				if (configuration.Channels[channel].Termination == ThunderscopeTermination.FiftyOhm)
+				{
+					datamoverRegister |= (uint)1 << (12 + channel);
+				}
+				if (!configuration.Channels[channel].Attenuator)
+				{
+					datamoverRegister |= (uint)1 << 16 + channel;
+				}
+				if (configuration.Channels[channel].Coupling == ThunderscopeCoupling.DC)
+				{
+					datamoverRegister |= (uint)1 << 20 + channel;
+				}
+			}
+			switch (numChannelsEnabled)
+			{
+				case 0:
+				case 1: break; // do nothing
+				case 2: datamoverRegister |= 0x10; break;
+				default: datamoverRegister |= 0x30; break;
+			}
+			Write32(BarRegister.DATAMOVER_REG_OUT, datamoverRegister);
+		}
+
+		private void ConfigureAdc()
+		{
+			// Reset ADC
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RESET, 0x0001);
+			// Power Down ADC
+			AdcPower(false);
+			// Invert channels
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INVERT, 0x007F);
+			// Adjust full scale value
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_FS_CNTRL, 0x0010);
+			// Course Gain On
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_GAIN_CFG, 0x0000);
+			// Course Gain 4-CH set
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_QUAD_GAIN, 0x9999);
+			// Course Gain 1-CH & 2-CH set
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_DUAL_GAIN, 0x0A99);
+			//Set adc into active mode
+			//currentBoardState.num_ch_on++;
+			//currentBoardState.ch_is_on[0] = true;
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_chnum_clkdiv,sizeof(currentBoardState.adc_chnum_clkdiv));
+
+			// Set 8-bit mode (for HMCAD1520, won't do anything for HMCAD1511)
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RES_SEL, 0x0000);
+
+			//Set LVDS phase to 0 Deg & Drive Strength to RSDS
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_PHASE, 0x0060);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_DRIVE, 0x0222);
+
+			AdcPower(true);
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_12,sizeof(currentBoardState.adc_in_sel_12));
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_34,sizeof(currentBoardState.adc_in_sel_34));
+
+			hardwareState.FrontEndEnabled = true;
+			ConfigureDatamover(hardwareState);
+		}
+
+		const byte SPI_BYTE_ADC = 0xFD;
+		private void SetAdcRegister(AdcRegister register, ushort value)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = SPI_BYTE_ADC;
+			fifo[1] = (byte)register;
+			fifo[2] = (byte)(value >> 8);
+			fifo[3] = (byte)(value & 0xff);
+			WriteFifo(fifo);
+		}
+
+		private void AdcPower(bool on)
+		{
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_POWER, (ushort)(on ? 0x0000 : 0x0200));
+		}
+
+		private void UpdateAdc()
+		{
+			byte[] on_channels = new byte[4];
+			int num_channels_on = 0;
+			for (int i = 0; i < 4; i++)
+			{
+				if (((configuration.EnabledChannels >> i) & 0x01) > 0)
+				{
+					on_channels[num_channels_on++] = (byte)(3 - i);
+				}
+			}
+
+			byte clkdiv;
+			switch (num_channels_on)
+			{
+				case 0:
+				case 1:
+					on_channels[3] = on_channels[2] = on_channels[1] = on_channels[0];
+					clkdiv = 0;
+					configuration.AdcChannelMode = AdcChannelMode.Single;
+					break;
+				case 2:
+					on_channels[2] = on_channels[3] = on_channels[1];
+					on_channels[1] = on_channels[0];
+					clkdiv = 1;
+					configuration.AdcChannelMode = AdcChannelMode.Dual;
+					break;
+				default:
+					on_channels[0] = 3;
+					on_channels[1] = 2;
+					on_channels[2] = 1;
+					on_channels[3] = 0;
+					num_channels_on = 4;
+					clkdiv = 2;
+					configuration.AdcChannelMode = AdcChannelMode.Quad;
+					break;
+			}
+
+			AdcPower(false);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_CHNUM_CLKDIV, (ushort)(clkdiv << 8 | num_channels_on));
+			AdcPower(true);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL12, (ushort)(2 << on_channels[0] | 512 << on_channels[1]));
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL34, (ushort)(2 << on_channels[2] | 512 << on_channels[3]));
+
+			ThunderscopeHardwareState temporaryState = hardwareState;
+			temporaryState.DatamoverEnabled = false;
+			temporaryState.FpgaAdcEnabled = false;
+			ConfigureDatamover(temporaryState);
+
+			Thread.Sleep(5);
+
+			if (num_channels_on != 0)
+				ConfigureDatamover(hardwareState);
+		}
+
+		private void SetDAC(int channel)
+		{
+			// value is 12-bit
+			// Is this right?? Or is it rounding wrong?
+			//uint dac_value = (uint)Math.Round((configuration.GetChannel(channel).VoltOffset + 0.5) * 4095);
+
+			ushort dacValue = channel switch
+			{
+				0 => calibration.Channel1.TrimOffsetDac,
+				1 => calibration.Channel2.TrimOffsetDac,
+				2 => calibration.Channel3.TrimOffsetDac,
+				3 => calibration.Channel4.TrimOffsetDac,
+			};
+			if (dacValue < 0)
+				throw new Exception("DAC offset too low");
+			if (dacValue > 0xFFF)
+				throw new Exception("DAC offset too high");
+
+			Span<byte> fifo = new byte[5];
+			fifo[0] = 0xFF;  // I2C
+			fifo[1] = 0xC0;  // DAC? New address is C0 since part is A0 variant
+			//fifo[2] = (byte)(0x40 + (channelIndex << 1));
+			fifo[2] = (byte)(0x58 + (channel << 1));       // p41 of MCP4728 datasheet
+			fifo[3] = (byte)(dacValue >> 8 & 0xF);     // Vref = VDD. Power down = normal mode. Gain = 1
+			fifo[4] = (byte)(dacValue & 0xFF);
+			WriteFifo(fifo);
+		}
+
+		private void SetPGA(int channel)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = (byte)(0xFB - channel);  // SPI chip enable
+			fifo[1] = 0;
+			fifo[2] = 0x04;  // ??
+			fifo[3] = configuration.Channels[channel].PgaConfigurationByte;
+			switch (configuration.Channels[channel].Bandwidth)
+			{
+				case 20: fifo[3] |= 0x40; break;
+				case 100: fifo[3] |= 0x80; break;
+				case 200: fifo[3] |= 0xC0; break;
+				case 350: /* 0 */ break;
+				default: throw new Exception("Invalid bandwidth");
+			}
+			WriteFifo(fifo);
+		}
+
+		private void UpdateBufferHead()
+		{
+			// 1 page = 4k
+			uint transfer_counter = Read32(BarRegister.DATAMOVER_TRANSFER_COUNTER);
+			uint error_code = transfer_counter >> 30;
+			if ((error_code & 2) > 0)
+				throw new Exception("Thunderscope - datamover error");
+
+			if ((error_code & 1) > 0)
+				throw new ThunderscopeFifoOverflowException("Thunderscope - FIFO overflow");
+
+			uint overflow_cycles = transfer_counter >> 16 & 0x3FFF;
+			if (overflow_cycles > 0)
+				throw new Exception("Thunderscope - pipeline overflow");
+
+			uint pages_moved = transfer_counter & 0xFFFF;
+			ulong buffer_head = hardwareState.BufferHead & ~0xFFFFUL | pages_moved;
+			if (buffer_head < hardwareState.BufferHead)
+				buffer_head += 0x10000UL;
+
+			hardwareState.BufferHead = buffer_head;
+
+			ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
+			if (pages_available >= hardwareState.RamSizePages)
+				throw new ThunderscopeMemoryOutOfMemoryException("Thunderscope - memory full");
+		}
+
+		// Channel passed by ref to do in-place updating
+		// Returns PGA configuration byte
+		public static void CalculateAfeConfiguration(ref ThunderscopeChannel channel)
+		{
+			double requestedVoltFullScale = channel.VoltFullScale;
+			double attenuatorFactor = 1.0 / 50.0;
+			double headroomFactor = 1.0;        // Buf802 has 0.961 so can get away with setting this to 1.0 instead of something like 0.95
+			double adcFullScaleRange = 0.7;     // Vpp
+			double adcFullScaleRangeWithHeadroom = headroomFactor * adcFullScaleRange;
+			// Remember the minimum PGA LNA gain is 10dB, that's a factor of 3.162 which might hit a PGA voltage rail internally before it has a chance to be attenuated...
+			// So might need to change this attenuatorThreasholdVolts calculation
+			double attenuatorThresholdVolts = adcFullScaleRangeWithHeadroom / Math.Pow(10, -1.14 / 20.0);   // -1.14dB is the minimum possible PGA gain however the PGA gain chain is 10dB + -20dB + 8.86dB, so be cautious.
+
+			// Check attenuator threshold and set afeAttenuatorEnabled if needed
+			channel.Attenuator = false;
+			if (requestedVoltFullScale > attenuatorThresholdVolts)
+			{
+				channel.Attenuator = true;
+				requestedVoltFullScale *= attenuatorFactor;
+			}
+
+			// Calculate the ideal PGA gain before searching the possible PGA gains (where possible range is -1.14dB to 38.8dB in 2dB steps)
+			double requestedPgaGainDb = 20 * Math.Log10(adcFullScaleRangeWithHeadroom / requestedVoltFullScale);
+
+			// Now check all the PGA gain options, starting from highest gain setting
+			bool gainFound = false;
+			bool lnaHighGain = true;
+			int n;
+			double pgaGainCalculation() { return (lnaHighGain ? 30 : 10) - 2 * n + 8.86; }
+			for (n = 0; n < 10; n++)
+			{
+				var potentialPgaGainDb = pgaGainCalculation();
+				if (potentialPgaGainDb < requestedPgaGainDb)
+				{
+					gainFound = true;
+					break;
+				}
+			}
+			if (!gainFound)
+			{
+				lnaHighGain = false;
+				for (n = 0; n <= 10; n++)
+				{
+					var potentialPgaGainDb = pgaGainCalculation();
+					if (potentialPgaGainDb < requestedPgaGainDb)
+					{
+						gainFound = true;
+						break;
+					}
+				}
+			}
+			if (!gainFound)
+				throw new NotSupportedException();
+
+			var actualPgaGainDb = pgaGainCalculation();
+			channel.ActualVoltFullScale = adcFullScaleRangeWithHeadroom / Math.Pow(10, actualPgaGainDb / 20);
+			if (channel.Attenuator)
+				channel.ActualVoltFullScale /= attenuatorFactor;
+
+			// Decode N into PGA LNA gain and PGA attentuator step
+			channel.PgaConfigurationByte = (byte)n;
+			if (lnaHighGain)
+				channel.PgaConfigurationByte |= 0x10;
+
+			// fifo[3] register
+			// [PGA LPF][PGA LPF][PGA LPF][PGA LNA gain][PGA attenuator][PGA attenuator][PGA attenuator][PGA attenuator]
+
+			// case 100: fifo[3] = 0x0A; break;
+			// case 50: fifo[3] = 0x07; break;
+			// case 20: fifo[3] = 0x03; break;
+			// case 10: fifo[3] = 0x1A; break;
+			// case 5: fifo[3] = 0x17; break;
+			// case 2: fifo[3] = 0x13; break;
+			// case 1: fifo[3] = 0x10; break;
+
+			// https://www.ti.com/lit/ds/symlink/lmh6518.pdf page 22
+			// case 20: fifo[3] |= 0x40; break;
+			// case 100: fifo[3] |= 0x80; break;
+			// case 200: fifo[3] |= 0xC0; break;
+			// case 350: /* 0 */ break;
+		}
+		private void ConfigurePLLRev1()
+		{
+			// These were provided by the chip configuration tool.
+			ushort[] config_clk_gen = {
+				0x0010, 0x010B, 0x0233, 0x08B0,
+				0x0901, 0x1000, 0x1180, 0x1501,
+				0x1600, 0x1705, 0x1900, 0x1A32,
+				0x1B00, 0x1C00, 0x1D00, 0x1E00,
+				0x1F00, 0x2001, 0x210C, 0x2228,
+				0x2303, 0x2408, 0x2500, 0x2600,
+				0x2700, 0x2F00, 0x3000, 0x3110,
+				0x3200, 0x3300, 0x3400, 0x3500,
+				0x3800, 0x4802 };
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length / 2; i++)
+			{
+				SetPllRegisterRev1((byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			hardwareState.PllEnabled = true;
+			ConfigureDatamover(hardwareState);
+		}
+
+		const byte I2C_BYTE_PLL_Rev1 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev1 = 0b10110000;
+		private void SetPllRegisterRev1(byte register, byte value)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = I2C_BYTE_PLL_Rev1;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev1;
+			fifo[2] = register;
+			fifo[3] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLLRev3()
+		{
+			//Strobe RST line on power on
+			Thread.Sleep(1);
+			hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+
+			// These were provided by the chip configuration tool.
+			uint[] config_clk_gen = {
+				0X000902, 0X062108, 0X063140, 0X010006,
+				0X010120, 0X010202, 0X010380, 0X010A20,
+				0X010B03, 0X01140D, 0X012006, 0X0125C0,
+				0X012660, 0X01277F, 0X012904, 0X012AB3,
+				0X012BC0, 0X012C80, 0X001C10, 0X001D80,
+				0X034003, 0X020141, 0X022135, 0X022240,
+				0X000C02, 0X000B01};
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length; i++)
+			{
+				SetPllRegisterRev3((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			Thread.Sleep(10);
+
+			SetPllRegisterRev3(0x00, 0x0D, 0x05);
+
+			Thread.Sleep(10);
+		}
+
+		const byte I2C_BYTE_PLL_Rev3 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev3 = 0b11011000;
+		const byte CLOCK_GEN_WRITE_COMMAND_Rev3 = 0x02;
+		private void SetPllRegisterRev3(byte reg_high, byte reg_low, byte value)
+		{
+			Span<byte> fifo = new byte[6];
+			fifo[0] = I2C_BYTE_PLL_Rev3;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev3;
+			fifo[2] = CLOCK_GEN_WRITE_COMMAND_Rev3;
+			fifo[3] = reg_high;
+			fifo[4] = reg_low;
+			fifo[5] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLLRev4()
+		{
+			//Strobe RST line on power on
+			Thread.Sleep(10);
+			hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(10);
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(10);
+
+			// These were provided by the chip configuration tool.
+			uint[] config_clk_gen = {
+				0x042308, 0x000301, 0x000402, 0x000521,
+				0x000701, 0x010042, 0x010100, 0x010201,
+				0x010600, 0x010700, 0x010800, 0x010900,
+				0x010A20, 0x010B03, 0x012160, 0x012790,
+				0x014100, 0x014200, 0x014300, 0x014400,
+				0x0145A0, 0x015300, 0x015450, 0x0155CE,
+				0x018000, 0x020080, 0x020105, 0x025080,
+				0x025102, 0x04300C, 0x043000};
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length; i++)
+			{
+				SetPllRegisterRev4((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			Thread.Sleep(10);
+
+			SetPllRegisterRev4((byte)(0x01), (byte)(0x00), (byte)(0x02)); //0x010002
+			SetPllRegisterRev4((byte)(0x01), (byte)(0x00), (byte)(0x42)); //0x010042
+
+			Thread.Sleep(10);
+		}
+
+		const byte I2C_BYTE_PLL_Rev4 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev4 = 0b11101000;
+		const byte CLOCK_GEN_WRITE_COMMAND_Rev4 = 0x02;
+		private void SetPllRegisterRev4(byte reg_high, byte reg_low, byte value)
+		{
+			Span<byte> fifo = new byte[6];
+			fifo[0] = I2C_BYTE_PLL_Rev4;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev4;
+			fifo[2] = CLOCK_GEN_WRITE_COMMAND_Rev4;
+			fifo[3] = reg_high;
+			fifo[4] = reg_low;
+			fifo[5] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLL()
+		{
+			switch (this.revision) 
+			{
+				case 1:
+					ConfigurePLLRev1();
+					break;
+				case 3:
+					ConfigurePLLRev3();
+					break;
+				case 4:
+					ConfigurePLLRev4();
+					break;
+				default:
+					throw new ArgumentNullException("No revision set for ThunderScope");
+					
+			}
+		}
+	}
 }

--- a/source/TS.NET/Drivers/XMDA/Thunderscope2.cs
+++ b/source/TS.NET/Drivers/XMDA/Thunderscope2.cs
@@ -6,637 +6,655 @@ using TS.NET.Driver.XMDA.Interop;
 
 namespace TS.NET.Driver.XMDA
 {
-    // This should be a simple interface with minimal state stored - leave that to the controlling application.
-    //   The reason being is that there is a lot of complexity in the next layer above (mainly around gain and offset calibration)
-    //   so it makes sense to keep all that state at a higher level and just expose things like "SetTrimDac(int channelIndex, ushort value)"
-    //   with no "Get" methods.
-    public class Thunderscope2
-    {
-        private ThunderscopeInterop interop;
-        private bool open = false;
-        private ThunderscopeHardwareState hardwareState = new();
-
-        public static List<ThunderscopeDevice> IterateDevices()
-        {
-            return ThunderscopeInterop.IterateDevices();
-        }
-
-        public void Open(ThunderscopeDevice device)
-        {
-            if (open)
-                Close();
-
-            interop = ThunderscopeInterop.CreateInterop(device);
-            Initialise();
-            open = true;
-        }
-
-        public void Close()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            open = false;
-        }
-
-        public void Start()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (hardwareState.DatamoverEnabled)
-                throw new Exception("Thunderscope already started");
-            hardwareState.DatamoverEnabled = true;
-            hardwareState.FpgaAdcEnabled = true;
-            hardwareState.BufferHead = 0;
-            hardwareState.BufferTail = 0;
-            ConfigureDatamover(hardwareState);
-        }
-
-        public void Stop()
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (!hardwareState.DatamoverEnabled)
-                throw new Exception("Thunderscope not started");
-            hardwareState.DatamoverEnabled = false;
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(5);
-            hardwareState.FpgaAdcEnabled = false;
-            ConfigureDatamover(hardwareState);
-        }
-
-        public void Read(ThunderscopeMemory data)     //ThunderscopeMemory ensures memory is aligned on 4k boundary
-        {
-            if (!open)
-                throw new Exception("Thunderscope not open");
-            if (!hardwareState.DatamoverEnabled)
-                throw new ThunderscopeNotRunningException("Thunderscope not started");
-
-            // Buffer data must be aligned to 4096
-            //if (0xFFF & (ptrdiff_t)data)
-            //{
-            //    throw new Exception("data not aligned to 4096 boundary");
-            //}
-
-            ulong length = ThunderscopeMemory.Length;
-            // Align length to 4096.
-            //length &= ~0xFFFUL;
-
-            UpdateBufferHead();
-
-            ulong dataIndex = 0;
-            while (length > 0)
-            {
-                ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
-                if (pages_available == 0)
-                {
-
-                    //Thread.Sleep(1);
-                    //Thread.Yield();
-                    Thread.SpinWait(1000);
-                    UpdateBufferHead();
-                    continue;
-                }
-                ulong pages_to_read = length >> 12;
-                if (pages_to_read > pages_available) pages_to_read = pages_available;
-                ulong buffer_read_pos = hardwareState.BufferTail % hardwareState.RamSizePages;
-                if (pages_to_read > hardwareState.RamSizePages - buffer_read_pos) pages_to_read = hardwareState.RamSizePages - buffer_read_pos;
-                if (pages_to_read > hardwareState.RamSizePages / 4) pages_to_read = hardwareState.RamSizePages / 4;
-
-                interop.ReadC2H(data, dataIndex, buffer_read_pos << 12, pages_to_read << 12);
-                //read_handle(ts, ts->c2h0_handle, dataPtr, buffer_read_pos << 12, pages_to_read << 12);
-
-                dataIndex += pages_to_read << 12;
-                length -= pages_to_read << 12;
-
-                // Update buffer head and calculate overflow BEFORE
-                // updating buffer tail as it is possible
-                // that a buffer overflow occured while we were reading.
-                UpdateBufferHead();
-                hardwareState.BufferTail += pages_to_read;
-            }
-        }
-
-        public void SetChannelEnables(bool channel1, bool channel2, bool channel3, bool channel4)
-        {
-            hardwareState.ChannelEnables[0] = channel1;
-            hardwareState.ChannelEnables[1] = channel2;
-            hardwareState.ChannelEnables[2] = channel3;
-            hardwareState.ChannelEnables[3] = channel4;
-
-            byte[] on_channels = new byte[4];
-            int num_channels_on = 0;
-            for (int i = 0; i < 4; i++)
-            {
-                if (hardwareState.ChannelEnables[i])
-                {
-                    on_channels[num_channels_on++] = (byte)i;
-                }
-            }
-
-            byte clkdiv;
-            switch (num_channels_on)
-            {
-                case 0:
-                case 1:
-                    on_channels[1] = on_channels[2] = on_channels[3] = on_channels[0];
-                    clkdiv = 0;
-                    break;
-                case 2:
-                    on_channels[2] = on_channels[3] = on_channels[1];
-                    on_channels[1] = on_channels[0];
-                    clkdiv = 1;
-                    break;
-                default:
-                    on_channels[0] = 0;
-                    on_channels[1] = 1;
-                    on_channels[2] = 2;
-                    on_channels[3] = 3;
-                    num_channels_on = 4;
-                    clkdiv = 2;
-                    break;
-            }
-
-            AdcPower(false);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_CHNUM_CLKDIV, (ushort)(clkdiv << 8 | num_channels_on));
-            AdcPower(true);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL12, (ushort)(2 << on_channels[0] | 512 << on_channels[1]));
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL34, (ushort)(2 << on_channels[2] | 512 << on_channels[3]));
-
-            ThunderscopeHardwareState temporaryState = hardwareState;
-            temporaryState.DatamoverEnabled = false;
-            temporaryState.FpgaAdcEnabled = false;
-            ConfigureDatamover(temporaryState);
-
-            Thread.Sleep(5);
-
-            if (num_channels_on != 0)
-                ConfigureDatamover(hardwareState);
-        }
-
-        // p22 of LMH6518 datasheet describes configuration byte
-        public void SetChannelPgaConfiguration(int channelIndex, byte configuration)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = (byte)(0xFB - channelIndex);  // SPI chip enable
-            fifo[1] = 0;
-            fifo[2] = 0x04;  // ??
-            fifo[3] = configuration;
-            WriteFifo(fifo);
-        }
-
-        // MCP4728
-        public void SetChannelTrimOffsetDac(int channelIndex, ushort value)
-        {
-            if (value < 0)
-                throw new ArgumentException("Value too low");
-            if (value > 0xFFF)
-                throw new ArgumentException("Value too high");
-
-            Span<byte> fifo = new byte[5];
-            fifo[0] = 0xFF;  // I2C
-            fifo[1] = 0xC0;  // Trim Offset DAC
-            //fifo[2] = (byte)(0x40 + (channelIndex << 1));
-            fifo[2] = (byte)(0x58 + (channelIndex << 1));       // p41 of MCP4728 datasheet
-            fifo[3] = (byte)(value >> 8 & 0xF);     // Vref = VDD. Power down = normal mode. Gain = 1
-            fifo[4] = (byte)(value & 0xFF);
-            WriteFifo(fifo);
-        }
-
-        public void SetChannelTrimSensitivityDac(int channelIndex, byte value)
-        {
-            if (value < 0)
-                throw new ArgumentException("Value too low");
-            if (value > 127)
-                throw new ArgumentException("Value too high");
-
-            Span<byte> fifo = new byte[5];
-            fifo[0] = 0xFF;  // I2C
-            fifo[1] = 0x58;  // Trim Sensitivity DAC
-            fifo[2] = (byte)(0x40 + (channelIndex << 1));
-            fifo[3] = (byte)(value >> 8 & 0xF);
-            fifo[4] = (byte)(value & 0xFF);
-            WriteFifo(fifo);
-        }
-
-        public void SetChannelMisc(int channelIndex) { }
-
-        public void ResetBuffer()
-        {
-            hardwareState.BufferHead = 0;
-            hardwareState.BufferTail = 0;
-            ConfigureDatamover(hardwareState);
-        }
-
-        private void Initialise()
-        {
-            Write32(BarRegister.DATAMOVER_REG_OUT, 0);
-
-            //Comment out below for Rev.1
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-            //Comment out above for Rev.1
-
-            hardwareState.BoardEnabled = true;
-            ConfigureDatamover(hardwareState);
-            ConfigurePLL();
-            ConfigureADC();
-
-            // Set up a default safe configuration
-            SetChannelEnables(true, true, true, true);
-
-            SetChannelPgaConfiguration(0, 0b11000101);      // 200MHz, 0dB
-            SetChannelPgaConfiguration(1, 0b11000101);      // 200MHz, 0dB
-            SetChannelPgaConfiguration(2, 0b11000101);      // 200MHz, 0dB
-            SetChannelPgaConfiguration(3, 0b11000101);      // 200MHz, 0dB
-
-            SetChannelTrimOffsetDac(0, 2048);
-            SetChannelTrimOffsetDac(1, 2048);
-            SetChannelTrimOffsetDac(2, 2048);
-            SetChannelTrimOffsetDac(3, 2048);
-        }
-
-        private uint Read32(BarRegister register)
-        {
-            Span<byte> bytes = new byte[4];
-            interop.ReadUser(bytes, (ulong)register);
-            return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
-        }
-
-        private void Write32(BarRegister register, uint value)
-        {
-            Span<byte> bytes = new byte[4];
-            BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
-            interop.WriteUser(bytes, (ulong)register);
-        }
-
-        private void WriteFifo(ReadOnlySpan<byte> data)
-        {
-            // reset ISR
-            Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
-            // read ISR and IER
-            Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS);
-            Read32(BarRegister.SERIAL_FIFO_IER_ADDRESS);
-            // enable IER
-            Write32(BarRegister.SERIAL_FIFO_IER_ADDRESS, 0x0C000000U);
-            // Set false TDR
-            Write32(BarRegister.SERIAL_FIFO_TDR_ADDRESS, 0x2U);
-            // Put data into queue
-            for (int i = 0; i < data.Length; i++)
-            {
-                // TODO: Replace with write32
-                interop.WriteUser(data.Slice(i, 1), (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
-            }
-            // read TDFV (vacancy byte)
-            Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
-            // write to TLR (the size of the packet)
-            Write32(BarRegister.SERIAL_FIFO_TLR_ADDRESS, (uint)(data.Length * 4));
-            // read ISR for a done value
-            while (Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS) >> 24 != 8)
-            {
-                Thread.Sleep(1);
-            }
-            // reset ISR
-            Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
-            // read TDFV
-            Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
-        }
-
-        private void ConfigureDatamover(ThunderscopeHardwareState state)
-        {
-            uint datamoverRegister = 0;
-            if (state.BoardEnabled) datamoverRegister |= 0x01000000;
-            if (state.PllEnabled) datamoverRegister |= 0x02000000;
-            if (state.FrontEndEnabled) datamoverRegister |= 0x04000000;
-            if (state.DatamoverEnabled) datamoverRegister |= 0x1;
-            if (state.FpgaAdcEnabled) datamoverRegister |= 0x2;
-
-            int numChannelsEnabled = 0;
-            for (int channel = 0; channel < 4; channel++)
-            {
-                if (state.ChannelEnables[channel])
-                {
-                    numChannelsEnabled++;
-                }
-                if (!state.ChannelAttenuators[channel])
-                {
-                    datamoverRegister |= (uint)1 << 16 + channel;
-                }
-                if (state.ChannelCoupling[channel] == ThunderscopeCoupling.DC)
-                {
-                    datamoverRegister |= (uint)1 << 20 + channel;
-                }
-            }
-            switch (numChannelsEnabled)
-            {
-                case 0:
-                case 1: break; // do nothing
-                case 2: datamoverRegister |= 0x10; break;
-                default: datamoverRegister |= 0x30; break;
-            }
-            Write32(BarRegister.DATAMOVER_REG_OUT, datamoverRegister);
-        }
-
-        private void ConfigureADC()
-        {
-            // Reset ADC
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RESET, 0x0001);
-            // Power Down ADC
-            AdcPower(false);
-            // Invert channels
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INVERT, 0x007F);
-            // Adjust full scale value
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_FS_CNTRL, 0x0010);
-            // Course Gain On
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_GAIN_CFG, 0x0000);
-            // Course Gain 4-CH set
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_QUAD_GAIN, 0x9999);
-            // Course Gain 1-CH & 2-CH set
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_DUAL_GAIN, 0x0A99);
-            //Set adc into active mode
-            //currentBoardState.num_ch_on++;
-            //currentBoardState.ch_is_on[0] = true;
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_chnum_clkdiv,sizeof(currentBoardState.adc_chnum_clkdiv));
-
-            // Set 8-bit mode (for HMCAD1520, won't do anything for HMCAD1511)
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RES_SEL, 0x0000);
-
-            //Set LVDS phase to 0 Deg & Drive Strength to RSDS
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_PHASE, 0x0060);
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_DRIVE, 0x0222);
-
-            AdcPower(true);
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_12,sizeof(currentBoardState.adc_in_sel_12));
-            //_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_34,sizeof(currentBoardState.adc_in_sel_34));
-
-            hardwareState.FrontEndEnabled = true;
-            ConfigureDatamover(hardwareState);
-        }
-
-        const byte SPI_BYTE_ADC = 0xFD;
-        private void SetAdcRegister(AdcRegister register, ushort value)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = SPI_BYTE_ADC;
-            fifo[1] = (byte)register;
-            fifo[2] = (byte)(value >> 8);
-            fifo[3] = (byte)(value & 0xff);
-            WriteFifo(fifo);
-        }
-
-        private void AdcPower(bool on)
-        {
-            SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_POWER, (ushort)(on ? 0x0000 : 0x0200));
-        }
-
-        private void UpdateBufferHead()
-        {
-            // 1 page = 4k
-            uint transfer_counter = Read32(BarRegister.DATAMOVER_TRANSFER_COUNTER);
-            uint error_code = transfer_counter >> 30;
-            if ((error_code & 2) > 0)
-                throw new Exception("Thunderscope - datamover error");
-
-            //if ((error_code & 1) > 0)
-            //    throw new ThunderscopeFIFOOverflowException("Thunderscope - FIFO overflow");
-
-            //uint overflow_cycles = transfer_counter >> 16 & 0x3FFF;
-            //if (overflow_cycles > 0)
-            //    throw new Exception("Thunderscope - pipeline overflow");
-
-            uint pages_moved = transfer_counter & 0xFFFF;
-            ulong buffer_head = hardwareState.BufferHead & ~0xFFFFUL | pages_moved;
-            if (buffer_head < hardwareState.BufferHead)
-                buffer_head += 0x10000UL;
-
-            hardwareState.BufferHead = buffer_head;
-
-            ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
-            if (pages_available >= hardwareState.RamSizePages)
-                throw new ThunderscopeMemoryOutOfMemoryException("Thunderscope - memory full");
-        }
-
-        // Channel passed by ref to do in-place updating
-        // Returns PGA configuration byte
-        public static void CalculateAfeConfiguration(ref ThunderscopeChannel channel)
-        {
-            double requestedVoltFullScale = channel.VoltFullScale;
-            double attenuatorFactor = 1.0 / 50.0;
-            double headroomFactor = 1.0;        // Buf802 has 0.961 so can get away with setting this to 1.0 instead of something like 0.95
-            double adcFullScaleRange = 0.7;     // Vpp
-            double adcFullScaleRangeWithHeadroom = headroomFactor * adcFullScaleRange;
-            // Remember the minimum PGA LNA gain is 10dB, that's a factor of 3.162 which might hit a PGA voltage rail internally before it has a chance to be attenuated...
-            // So might need to change this attenuatorThreasholdVolts calculation
-            double attenuatorThresholdVolts = adcFullScaleRangeWithHeadroom / Math.Pow(10, -1.14 / 20.0);   // -1.14dB is the minimum possible PGA gain however the PGA gain chain is 10dB + -20dB + 8.86dB, so be cautious.
-
-            // Check attenuator threshold and set afeAttenuatorEnabled if needed
-            channel.Attenuator = false;
-            if (requestedVoltFullScale > attenuatorThresholdVolts)
-            {
-                channel.Attenuator = true;
-                requestedVoltFullScale *= attenuatorFactor;
-            }
-
-            // Calculate the ideal PGA gain before searching the possible PGA gains (where possible range is -1.14dB to 38.8dB in 2dB steps)
-            double requestedPgaGainDb = 20 * Math.Log10(adcFullScaleRangeWithHeadroom / requestedVoltFullScale);
-
-            // Now check all the PGA gain options, starting from highest gain setting
-            bool gainFound = false;
-            bool lnaHighGain = true;
-            int n;
-            double pgaGainCalculation() { return (lnaHighGain ? 30 : 10) - 2 * n + 8.86; }
-            for (n = 0; n < 10; n++)
-            {
-                var potentialPgaGainDb = pgaGainCalculation();
-                if (potentialPgaGainDb < requestedPgaGainDb)
-                {
-                    gainFound = true;
-                    break;
-                }
-            }
-            if (!gainFound)
-            {
-                lnaHighGain = false;
-                for (n = 0; n <= 10; n++)
-                {
-                    var potentialPgaGainDb = pgaGainCalculation();
-                    if (potentialPgaGainDb < requestedPgaGainDb)
-                    {
-                        gainFound = true;
-                        break;
-                    }
-                }
-            }
-            if (!gainFound)
-                throw new NotSupportedException();
-
-            var actualPgaGainDb = pgaGainCalculation();
-            channel.ActualVoltFullScale = adcFullScaleRangeWithHeadroom / Math.Pow(10, actualPgaGainDb / 20);
-            if (channel.Attenuator)
-                channel.ActualVoltFullScale /= attenuatorFactor;
-
-            // Decode N into PGA LNA gain and PGA attentuator step
-            channel.PgaConfigurationByte = (byte)n;
-            if (lnaHighGain)
-                channel.PgaConfigurationByte |= 0x10;
-
-            // fifo[3] register
-            // [PGA LPF][PGA LPF][PGA LPF][PGA LNA gain][PGA attenuator][PGA attenuator][PGA attenuator][PGA attenuator]
-
-            // case 100: fifo[3] = 0x0A; break;
-            // case 50: fifo[3] = 0x07; break;
-            // case 20: fifo[3] = 0x03; break;
-            // case 10: fifo[3] = 0x1A; break;
-            // case 5: fifo[3] = 0x17; break;
-            // case 2: fifo[3] = 0x13; break;
-            // case 1: fifo[3] = 0x10; break;
-
-            // https://www.ti.com/lit/ds/symlink/lmh6518.pdf page 22
-            // case 20: fifo[3] |= 0x40; break;
-            // case 100: fifo[3] |= 0x80; break;
-            // case 200: fifo[3] |= 0xC0; break;
-            // case 350: /* 0 */ break;
-        }
-#if TsRev1
-        private void ConfigurePLL()
-        {
-            // These were provided by the chip configuration tool.
-            ushort[] config_clk_gen = {
-                0x0010, 0x010B, 0x0233, 0x08B0,
-                0x0901, 0x1000, 0x1180, 0x1501,
-                0x1600, 0x1705, 0x1900, 0x1A32,
-                0x1B00, 0x1C00, 0x1D00, 0x1E00,
-                0x1F00, 0x2001, 0x210C, 0x2228,
-                0x2303, 0x2408, 0x2500, 0x2600,
-                0x2700, 0x2F00, 0x3000, 0x3110,
-                0x3200, 0x3300, 0x3400, 0x3500,
-                0x3800, 0x4802 };
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length / 2; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            hardwareState.PllEnabled = true;
-            ConfigureDatamover(hardwareState);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b10110000;
-        private void SetPllRegister(byte register, byte value)
-        {
-            Span<byte> fifo = new byte[4];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = register;
-            fifo[3] = value;
-            WriteFifo(fifo);
-        }
-#endif
-
-#if TsRev3
-        private void ConfigurePLL()
-        {
-            //Strobe RST line on power on
-            Thread.Sleep(1);
-            hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(1);
-
-            // These were provided by the chip configuration tool.
-            uint[] config_clk_gen = {
-                0X000902, 0X062108, 0X063140, 0X010006,
-                0X010120, 0X010202, 0X010380, 0X010A20,
-                0X010B03, 0X01140D, 0X012006, 0X0125C0,
-                0X012660, 0X01277F, 0X012904, 0X012AB3,
-                0X012BC0, 0X012C80, 0X001C10, 0X001D80,
-                0X034003, 0X020141, 0X022135, 0X022240,
-                0X000C02, 0X000B01};
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            Thread.Sleep(10);
-
-            SetPllRegister(0x00, 0x0D, 0x05);
-
-            Thread.Sleep(10);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b11011000;
-        const byte CLOCK_GEN_WRITE_COMMAND = 0x02;
-        private void SetPllRegister(byte reg_high, byte reg_low, byte value)
-        {
-            Span<byte> fifo = new byte[6];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = CLOCK_GEN_WRITE_COMMAND;
-            fifo[3] = reg_high;
-            fifo[4] = reg_low;
-            fifo[5] = value;
-            WriteFifo(fifo);
-        }
-#endif
-
-#if TsRev4
-        private void ConfigurePLL()
-        {
-            //Strobe RST line on power on
-            Thread.Sleep(10);
-            hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(10);
-            hardwareState.PllEnabled = true;    //RSTn high --> PLL active
-            ConfigureDatamover(hardwareState);
-            Thread.Sleep(10);
-
-            // These were provided by the chip configuration tool.
-            uint[] config_clk_gen = {
-                0x042308, 0x000301, 0x000402, 0x000521,
-                0x000701, 0x010042, 0x010100, 0x010201,
-                0x010600, 0x010700, 0x010800, 0x010900,
-                0x010A20, 0x010B03, 0x012160, 0x012790,
-                0x014100, 0x014200, 0x014300, 0x014400,
-                0x0145A0, 0x015300, 0x015450, 0x0155CE,
-                0x018000, 0x020080, 0x020105, 0x025080,
-                0x025102, 0x04300C, 0x043000};
-
-            // write to the clock generator
-            for (int i = 0; i < config_clk_gen.Length; i++)
-            {
-                SetPllRegister((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
-            }
-
-            Thread.Sleep(10);
-
-            SetPllRegister((byte)(0x01), (byte)(0x00), (byte)(0x02)); //0x010002
-            SetPllRegister((byte)(0x01), (byte)(0x00), (byte)(0x42)); //0x010042
-
-            Thread.Sleep(10);
-        }
-
-        const byte I2C_BYTE_PLL = 0xFF;
-        const byte CLOCK_GEN_I2C_ADDRESS_WRITE = 0b11101000;
-        const byte CLOCK_GEN_WRITE_COMMAND = 0x02;
-        private void SetPllRegister(byte reg_high, byte reg_low, byte value)
-        {
-            Span<byte> fifo = new byte[6];
-            fifo[0] = I2C_BYTE_PLL;
-            fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE;
-            fifo[2] = CLOCK_GEN_WRITE_COMMAND;
-            fifo[3] = reg_high;
-            fifo[4] = reg_low;
-            fifo[5] = value;
-            WriteFifo(fifo);
-        }
-#endif
-    }
+	// This should be a simple interface with minimal state stored - leave that to the controlling application.
+	//   The reason being is that there is a lot of complexity in the next layer above (mainly around gain and offset calibration)
+	//   so it makes sense to keep all that state at a higher level and just expose things like "SetTrimDac(int channelIndex, ushort value)"
+	//   with no "Get" methods.
+	public class Thunderscope2
+	{
+		private ThunderscopeInterop interop;
+		private bool open = false;
+		private ThunderscopeHardwareState hardwareState = new();
+		private int revision;
+
+		public static List<ThunderscopeDevice> IterateDevices()
+		{
+			return ThunderscopeInterop.IterateDevices();
+		}
+
+		public void Open(ThunderscopeDevice device, int revision = 4)
+		{
+			if (open)
+				Close();
+			
+			interop = ThunderscopeInterop.CreateInterop(device);
+			this.revision = revision;
+			
+			Initialise();
+			open = true;
+		}
+
+		public void Close()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			open = false;
+		}
+
+		public void Start()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (hardwareState.DatamoverEnabled)
+				throw new Exception("Thunderscope already started");
+			hardwareState.DatamoverEnabled = true;
+			hardwareState.FpgaAdcEnabled = true;
+			hardwareState.BufferHead = 0;
+			hardwareState.BufferTail = 0;
+			ConfigureDatamover(hardwareState);
+		}
+
+		public void Stop()
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (!hardwareState.DatamoverEnabled)
+				throw new Exception("Thunderscope not started");
+			hardwareState.DatamoverEnabled = false;
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(5);
+			hardwareState.FpgaAdcEnabled = false;
+			ConfigureDatamover(hardwareState);
+		}
+
+		public void Read(ThunderscopeMemory data)     //ThunderscopeMemory ensures memory is aligned on 4k boundary
+		{
+			if (!open)
+				throw new Exception("Thunderscope not open");
+			if (!hardwareState.DatamoverEnabled)
+				throw new ThunderscopeNotRunningException("Thunderscope not started");
+
+			// Buffer data must be aligned to 4096
+			//if (0xFFF & (ptrdiff_t)data)
+			//{
+			//    throw new Exception("data not aligned to 4096 boundary");
+			//}
+
+			ulong length = ThunderscopeMemory.Length;
+			// Align length to 4096.
+			//length &= ~0xFFFUL;
+
+			UpdateBufferHead();
+
+			ulong dataIndex = 0;
+			while (length > 0)
+			{
+				ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
+				if (pages_available == 0)
+				{
+
+					//Thread.Sleep(1);
+					//Thread.Yield();
+					Thread.SpinWait(1000);
+					UpdateBufferHead();
+					continue;
+				}
+				ulong pages_to_read = length >> 12;
+				if (pages_to_read > pages_available) pages_to_read = pages_available;
+				ulong buffer_read_pos = hardwareState.BufferTail % hardwareState.RamSizePages;
+				if (pages_to_read > hardwareState.RamSizePages - buffer_read_pos) pages_to_read = hardwareState.RamSizePages - buffer_read_pos;
+				if (pages_to_read > hardwareState.RamSizePages / 4) pages_to_read = hardwareState.RamSizePages / 4;
+
+				interop.ReadC2H(data, dataIndex, buffer_read_pos << 12, pages_to_read << 12);
+				//read_handle(ts, ts->c2h0_handle, dataPtr, buffer_read_pos << 12, pages_to_read << 12);
+
+				dataIndex += pages_to_read << 12;
+				length -= pages_to_read << 12;
+
+				// Update buffer head and calculate overflow BEFORE
+				// updating buffer tail as it is possible
+				// that a buffer overflow occured while we were reading.
+				UpdateBufferHead();
+				hardwareState.BufferTail += pages_to_read;
+			}
+		}
+
+		public void SetChannelEnables(bool channel1, bool channel2, bool channel3, bool channel4)
+		{
+			hardwareState.ChannelEnables[0] = channel1;
+			hardwareState.ChannelEnables[1] = channel2;
+			hardwareState.ChannelEnables[2] = channel3;
+			hardwareState.ChannelEnables[3] = channel4;
+
+			byte[] on_channels = new byte[4];
+			int num_channels_on = 0;
+			for (int i = 0; i < 4; i++)
+			{
+				if (hardwareState.ChannelEnables[i])
+				{
+					on_channels[num_channels_on++] = (byte)i;
+				}
+			}
+
+			byte clkdiv;
+			switch (num_channels_on)
+			{
+				case 0:
+				case 1:
+					on_channels[1] = on_channels[2] = on_channels[3] = on_channels[0];
+					clkdiv = 0;
+					break;
+				case 2:
+					on_channels[2] = on_channels[3] = on_channels[1];
+					on_channels[1] = on_channels[0];
+					clkdiv = 1;
+					break;
+				default:
+					on_channels[0] = 0;
+					on_channels[1] = 1;
+					on_channels[2] = 2;
+					on_channels[3] = 3;
+					num_channels_on = 4;
+					clkdiv = 2;
+					break;
+			}
+
+			AdcPower(false);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_CHNUM_CLKDIV, (ushort)(clkdiv << 8 | num_channels_on));
+			AdcPower(true);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL12, (ushort)(2 << on_channels[0] | 512 << on_channels[1]));
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INSEL34, (ushort)(2 << on_channels[2] | 512 << on_channels[3]));
+
+			ThunderscopeHardwareState temporaryState = hardwareState;
+			temporaryState.DatamoverEnabled = false;
+			temporaryState.FpgaAdcEnabled = false;
+			ConfigureDatamover(temporaryState);
+
+			Thread.Sleep(5);
+
+			if (num_channels_on != 0)
+				ConfigureDatamover(hardwareState);
+		}
+
+		// p22 of LMH6518 datasheet describes configuration byte
+		public void SetChannelPgaConfiguration(int channelIndex, byte configuration)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = (byte)(0xFB - channelIndex);  // SPI chip enable
+			fifo[1] = 0;
+			fifo[2] = 0x04;  // ??
+			fifo[3] = configuration;
+			WriteFifo(fifo);
+		}
+
+		// MCP4728
+		public void SetChannelTrimOffsetDac(int channelIndex, ushort value)
+		{
+			if (value < 0)
+				throw new ArgumentException("Value too low");
+			if (value > 0xFFF)
+				throw new ArgumentException("Value too high");
+
+			Span<byte> fifo = new byte[5];
+			fifo[0] = 0xFF;  // I2C
+			fifo[1] = 0xC0;  // Trim Offset DAC
+			//fifo[2] = (byte)(0x40 + (channelIndex << 1));
+			fifo[2] = (byte)(0x58 + (channelIndex << 1));       // p41 of MCP4728 datasheet
+			fifo[3] = (byte)(value >> 8 & 0xF);     // Vref = VDD. Power down = normal mode. Gain = 1
+			fifo[4] = (byte)(value & 0xFF);
+			WriteFifo(fifo);
+		}
+
+		public void SetChannelTrimSensitivityDac(int channelIndex, byte value)
+		{
+			if (value < 0)
+				throw new ArgumentException("Value too low");
+			if (value > 127)
+				throw new ArgumentException("Value too high");
+
+			Span<byte> fifo = new byte[5];
+			fifo[0] = 0xFF;  // I2C
+			fifo[1] = 0x58;  // Trim Sensitivity DAC
+			fifo[2] = (byte)(0x40 + (channelIndex << 1));
+			fifo[3] = (byte)(value >> 8 & 0xF);
+			fifo[4] = (byte)(value & 0xFF);
+			WriteFifo(fifo);
+		}
+
+		public void SetChannelMisc(int channelIndex) { }
+
+		public void ResetBuffer()
+		{
+			hardwareState.BufferHead = 0;
+			hardwareState.BufferTail = 0;
+			ConfigureDatamover(hardwareState);
+		}
+
+		private void Initialise()
+		{
+			Write32(BarRegister.DATAMOVER_REG_OUT, 0);
+
+			//Comment out below for Rev.1
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+			//Comment out above for Rev.1
+
+			hardwareState.BoardEnabled = true;
+			ConfigureDatamover(hardwareState);
+			ConfigurePLL();
+			ConfigureADC();
+
+			// Set up a default safe configuration
+			SetChannelEnables(true, true, true, true);
+
+			SetChannelPgaConfiguration(0, 0b11000101);      // 200MHz, 0dB
+			SetChannelPgaConfiguration(1, 0b11000101);      // 200MHz, 0dB
+			SetChannelPgaConfiguration(2, 0b11000101);      // 200MHz, 0dB
+			SetChannelPgaConfiguration(3, 0b11000101);      // 200MHz, 0dB
+
+			SetChannelTrimOffsetDac(0, 2048);
+			SetChannelTrimOffsetDac(1, 2048);
+			SetChannelTrimOffsetDac(2, 2048);
+			SetChannelTrimOffsetDac(3, 2048);
+		}
+
+		private uint Read32(BarRegister register)
+		{
+			Span<byte> bytes = new byte[4];
+			interop.ReadUser(bytes, (ulong)register);
+			return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+		}
+
+		private void Write32(BarRegister register, uint value)
+		{
+			Span<byte> bytes = new byte[4];
+			BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+			interop.WriteUser(bytes, (ulong)register);
+		}
+
+		private void WriteFifo(ReadOnlySpan<byte> data)
+		{
+			// reset ISR
+			Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
+			// read ISR and IER
+			Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS);
+			Read32(BarRegister.SERIAL_FIFO_IER_ADDRESS);
+			// enable IER
+			Write32(BarRegister.SERIAL_FIFO_IER_ADDRESS, 0x0C000000U);
+			// Set false TDR
+			Write32(BarRegister.SERIAL_FIFO_TDR_ADDRESS, 0x2U);
+			// Put data into queue
+			for (int i = 0; i < data.Length; i++)
+			{
+				// TODO: Replace with write32
+				interop.WriteUser(data.Slice(i, 1), (ulong)BarRegister.SERIAL_FIFO_DATA_WRITE_REG);
+			}
+			// read TDFV (vacancy byte)
+			Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
+			// write to TLR (the size of the packet)
+			Write32(BarRegister.SERIAL_FIFO_TLR_ADDRESS, (uint)(data.Length * 4));
+			// read ISR for a done value
+			while (Read32(BarRegister.SERIAL_FIFO_ISR_ADDRESS) >> 24 != 8)
+			{
+				Thread.Sleep(1);
+			}
+			// reset ISR
+			Write32(BarRegister.SERIAL_FIFO_ISR_ADDRESS, 0xFFFFFFFFU);
+			// read TDFV
+			Read32(BarRegister.SERIAL_FIFO_TDFV_ADDRESS);
+		}
+
+		private void ConfigureDatamover(ThunderscopeHardwareState state)
+		{
+			uint datamoverRegister = 0;
+			if (state.BoardEnabled) datamoverRegister |= 0x01000000;
+			if (state.PllEnabled) datamoverRegister |= 0x02000000;
+			if (state.FrontEndEnabled) datamoverRegister |= 0x04000000;
+			if (state.DatamoverEnabled) datamoverRegister |= 0x1;
+			if (state.FpgaAdcEnabled) datamoverRegister |= 0x2;
+
+			int numChannelsEnabled = 0;
+			for (int channel = 0; channel < 4; channel++)
+			{
+				if (state.ChannelEnables[channel])
+				{
+					numChannelsEnabled++;
+				}
+				if (!state.ChannelAttenuators[channel])
+				{
+					datamoverRegister |= (uint)1 << 16 + channel;
+				}
+				if (state.ChannelCoupling[channel] == ThunderscopeCoupling.DC)
+				{
+					datamoverRegister |= (uint)1 << 20 + channel;
+				}
+			}
+			switch (numChannelsEnabled)
+			{
+				case 0:
+				case 1: break; // do nothing
+				case 2: datamoverRegister |= 0x10; break;
+				default: datamoverRegister |= 0x30; break;
+			}
+			Write32(BarRegister.DATAMOVER_REG_OUT, datamoverRegister);
+		}
+
+		private void ConfigureADC()
+		{
+			// Reset ADC
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RESET, 0x0001);
+			// Power Down ADC
+			AdcPower(false);
+			// Invert channels
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_INVERT, 0x007F);
+			// Adjust full scale value
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_FS_CNTRL, 0x0010);
+			// Course Gain On
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_GAIN_CFG, 0x0000);
+			// Course Gain 4-CH set
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_QUAD_GAIN, 0x9999);
+			// Course Gain 1-CH & 2-CH set
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_DUAL_GAIN, 0x0A99);
+			//Set adc into active mode
+			//currentBoardState.num_ch_on++;
+			//currentBoardState.ch_is_on[0] = true;
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_chnum_clkdiv,sizeof(currentBoardState.adc_chnum_clkdiv));
+
+			// Set 8-bit mode (for HMCAD1520, won't do anything for HMCAD1511)
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_RES_SEL, 0x0000);
+
+			//Set LVDS phase to 0 Deg & Drive Strength to RSDS
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_PHASE, 0x0060);
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_LVDS_DRIVE, 0x0222);
+
+			AdcPower(true);
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_12,sizeof(currentBoardState.adc_in_sel_12));
+			//_FIFO_WRITE(user_handle,currentBoardState.adc_in_sel_34,sizeof(currentBoardState.adc_in_sel_34));
+
+			hardwareState.FrontEndEnabled = true;
+			ConfigureDatamover(hardwareState);
+		}
+
+		const byte SPI_BYTE_ADC = 0xFD;
+		private void SetAdcRegister(AdcRegister register, ushort value)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = SPI_BYTE_ADC;
+			fifo[1] = (byte)register;
+			fifo[2] = (byte)(value >> 8);
+			fifo[3] = (byte)(value & 0xff);
+			WriteFifo(fifo);
+		}
+
+		private void AdcPower(bool on)
+		{
+			SetAdcRegister(AdcRegister.THUNDERSCOPEHW_ADC_REG_POWER, (ushort)(on ? 0x0000 : 0x0200));
+		}
+
+		private void UpdateBufferHead()
+		{
+			// 1 page = 4k
+			uint transfer_counter = Read32(BarRegister.DATAMOVER_TRANSFER_COUNTER);
+			uint error_code = transfer_counter >> 30;
+			if ((error_code & 2) > 0)
+				throw new Exception("Thunderscope - datamover error");
+
+			//if ((error_code & 1) > 0)
+			//    throw new ThunderscopeFIFOOverflowException("Thunderscope - FIFO overflow");
+
+			//uint overflow_cycles = transfer_counter >> 16 & 0x3FFF;
+			//if (overflow_cycles > 0)
+			//    throw new Exception("Thunderscope - pipeline overflow");
+
+			uint pages_moved = transfer_counter & 0xFFFF;
+			ulong buffer_head = hardwareState.BufferHead & ~0xFFFFUL | pages_moved;
+			if (buffer_head < hardwareState.BufferHead)
+				buffer_head += 0x10000UL;
+
+			hardwareState.BufferHead = buffer_head;
+
+			ulong pages_available = hardwareState.BufferHead - hardwareState.BufferTail;
+			if (pages_available >= hardwareState.RamSizePages)
+				throw new ThunderscopeMemoryOutOfMemoryException("Thunderscope - memory full");
+		}
+
+		// Channel passed by ref to do in-place updating
+		// Returns PGA configuration byte
+		public static void CalculateAfeConfiguration(ref ThunderscopeChannel channel)
+		{
+			double requestedVoltFullScale = channel.VoltFullScale;
+			double attenuatorFactor = 1.0 / 50.0;
+			double headroomFactor = 1.0;        // Buf802 has 0.961 so can get away with setting this to 1.0 instead of something like 0.95
+			double adcFullScaleRange = 0.7;     // Vpp
+			double adcFullScaleRangeWithHeadroom = headroomFactor * adcFullScaleRange;
+			// Remember the minimum PGA LNA gain is 10dB, that's a factor of 3.162 which might hit a PGA voltage rail internally before it has a chance to be attenuated...
+			// So might need to change this attenuatorThreasholdVolts calculation
+			double attenuatorThresholdVolts = adcFullScaleRangeWithHeadroom / Math.Pow(10, -1.14 / 20.0);   // -1.14dB is the minimum possible PGA gain however the PGA gain chain is 10dB + -20dB + 8.86dB, so be cautious.
+
+			// Check attenuator threshold and set afeAttenuatorEnabled if needed
+			channel.Attenuator = false;
+			if (requestedVoltFullScale > attenuatorThresholdVolts)
+			{
+				channel.Attenuator = true;
+				requestedVoltFullScale *= attenuatorFactor;
+			}
+
+			// Calculate the ideal PGA gain before searching the possible PGA gains (where possible range is -1.14dB to 38.8dB in 2dB steps)
+			double requestedPgaGainDb = 20 * Math.Log10(adcFullScaleRangeWithHeadroom / requestedVoltFullScale);
+
+			// Now check all the PGA gain options, starting from highest gain setting
+			bool gainFound = false;
+			bool lnaHighGain = true;
+			int n;
+			double pgaGainCalculation() { return (lnaHighGain ? 30 : 10) - 2 * n + 8.86; }
+			for (n = 0; n < 10; n++)
+			{
+				var potentialPgaGainDb = pgaGainCalculation();
+				if (potentialPgaGainDb < requestedPgaGainDb)
+				{
+					gainFound = true;
+					break;
+				}
+			}
+			if (!gainFound)
+			{
+				lnaHighGain = false;
+				for (n = 0; n <= 10; n++)
+				{
+					var potentialPgaGainDb = pgaGainCalculation();
+					if (potentialPgaGainDb < requestedPgaGainDb)
+					{
+						gainFound = true;
+						break;
+					}
+				}
+			}
+			if (!gainFound)
+				throw new NotSupportedException();
+
+			var actualPgaGainDb = pgaGainCalculation();
+			channel.ActualVoltFullScale = adcFullScaleRangeWithHeadroom / Math.Pow(10, actualPgaGainDb / 20);
+			if (channel.Attenuator)
+				channel.ActualVoltFullScale /= attenuatorFactor;
+
+			// Decode N into PGA LNA gain and PGA attentuator step
+			channel.PgaConfigurationByte = (byte)n;
+			if (lnaHighGain)
+				channel.PgaConfigurationByte |= 0x10;
+
+			// fifo[3] register
+			// [PGA LPF][PGA LPF][PGA LPF][PGA LNA gain][PGA attenuator][PGA attenuator][PGA attenuator][PGA attenuator]
+
+			// case 100: fifo[3] = 0x0A; break;
+			// case 50: fifo[3] = 0x07; break;
+			// case 20: fifo[3] = 0x03; break;
+			// case 10: fifo[3] = 0x1A; break;
+			// case 5: fifo[3] = 0x17; break;
+			// case 2: fifo[3] = 0x13; break;
+			// case 1: fifo[3] = 0x10; break;
+
+			// https://www.ti.com/lit/ds/symlink/lmh6518.pdf page 22
+			// case 20: fifo[3] |= 0x40; break;
+			// case 100: fifo[3] |= 0x80; break;
+			// case 200: fifo[3] |= 0xC0; break;
+			// case 350: /* 0 */ break;
+		}
+
+
+		private void ConfigurePLLRev1()
+		{
+			// These were provided by the chip configuration tool.
+			ushort[] config_clk_gen = {
+				0x0010, 0x010B, 0x0233, 0x08B0,
+				0x0901, 0x1000, 0x1180, 0x1501,
+				0x1600, 0x1705, 0x1900, 0x1A32,
+				0x1B00, 0x1C00, 0x1D00, 0x1E00,
+				0x1F00, 0x2001, 0x210C, 0x2228,
+				0x2303, 0x2408, 0x2500, 0x2600,
+				0x2700, 0x2F00, 0x3000, 0x3110,
+				0x3200, 0x3300, 0x3400, 0x3500,
+				0x3800, 0x4802 };
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length / 2; i++)
+			{
+				SetPllRegisterRev1((byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			hardwareState.PllEnabled = true;
+			ConfigureDatamover(hardwareState);
+		}
+
+		const byte I2C_BYTE_PLL_Rev1 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev1 = 0b10110000;
+		private void SetPllRegisterRev1(byte register, byte value)
+		{
+			Span<byte> fifo = new byte[4];
+			fifo[0] = I2C_BYTE_PLL_Rev1;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev1;
+			fifo[2] = register;
+			fifo[3] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLLRev3()
+		{
+			//Strobe RST line on power on
+			Thread.Sleep(1);
+			hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(1);
+
+			// These were provided by the chip configuration tool.
+			uint[] config_clk_gen = {
+				0X000902, 0X062108, 0X063140, 0X010006,
+				0X010120, 0X010202, 0X010380, 0X010A20,
+				0X010B03, 0X01140D, 0X012006, 0X0125C0,
+				0X012660, 0X01277F, 0X012904, 0X012AB3,
+				0X012BC0, 0X012C80, 0X001C10, 0X001D80,
+				0X034003, 0X020141, 0X022135, 0X022240,
+				0X000C02, 0X000B01};
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length; i++)
+			{
+				SetPllRegisterRev3((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			Thread.Sleep(10);
+
+			SetPllRegisterRev3(0x00, 0x0D, 0x05);
+
+			Thread.Sleep(10);
+		}
+
+		const byte I2C_BYTE_PLL_Rev3 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev3 = 0b11011000;
+		const byte CLOCK_GEN_WRITE_COMMAND_Rev3 = 0x02;
+		private void SetPllRegisterRev3(byte reg_high, byte reg_low, byte value)
+		{
+			Span<byte> fifo = new byte[6];
+			fifo[0] = I2C_BYTE_PLL_Rev3;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev3;
+			fifo[2] = CLOCK_GEN_WRITE_COMMAND_Rev3;
+			fifo[3] = reg_high;
+			fifo[4] = reg_low;
+			fifo[5] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLLRev4()
+		{
+			//Strobe RST line on power on
+			Thread.Sleep(10);
+			hardwareState.PllEnabled = false;    //RSTn low --> PLL reset
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(10);
+			hardwareState.PllEnabled = true;    //RSTn high --> PLL active
+			ConfigureDatamover(hardwareState);
+			Thread.Sleep(10);
+
+			// These were provided by the chip configuration tool.
+			uint[] config_clk_gen = {
+				0x042308, 0x000301, 0x000402, 0x000521,
+				0x000701, 0x010042, 0x010100, 0x010201,
+				0x010600, 0x010700, 0x010800, 0x010900,
+				0x010A20, 0x010B03, 0x012160, 0x012790,
+				0x014100, 0x014200, 0x014300, 0x014400,
+				0x0145A0, 0x015300, 0x015450, 0x0155CE,
+				0x018000, 0x020080, 0x020105, 0x025080,
+				0x025102, 0x04300C, 0x043000};
+
+			// write to the clock generator
+			for (int i = 0; i < config_clk_gen.Length; i++)
+			{
+				SetPllRegisterRev4((byte)(config_clk_gen[i] >> 16), (byte)(config_clk_gen[i] >> 8), (byte)(config_clk_gen[i] & 0xff));
+			}
+
+			Thread.Sleep(10);
+
+			SetPllRegisterRev4((byte)(0x01), (byte)(0x00), (byte)(0x02)); //0x010002
+			SetPllRegisterRev4((byte)(0x01), (byte)(0x00), (byte)(0x42)); //0x010042
+
+			Thread.Sleep(10);
+		}
+
+		const byte I2C_BYTE_PLL_Rev4 = 0xFF;
+		const byte CLOCK_GEN_I2C_ADDRESS_WRITE_Rev4 = 0b11101000;
+		const byte CLOCK_GEN_WRITE_COMMAND_Rev4 = 0x02;
+		private void SetPllRegisterRev4(byte reg_high, byte reg_low, byte value)
+		{
+			Span<byte> fifo = new byte[6];
+			fifo[0] = I2C_BYTE_PLL_Rev4;
+			fifo[1] = CLOCK_GEN_I2C_ADDRESS_WRITE_Rev4;
+			fifo[2] = CLOCK_GEN_WRITE_COMMAND_Rev4;
+			fifo[3] = reg_high;
+			fifo[4] = reg_low;
+			fifo[5] = value;
+			WriteFifo(fifo);
+		}
+
+		private void ConfigurePLL()
+		{
+			switch (this.revision) 
+			{
+				case 1:
+					ConfigurePLLRev1();
+					break;
+				case 3:
+					ConfigurePLLRev3();
+					break;
+				case 4:
+					ConfigurePLLRev4();
+					break;
+				default:
+					throw new ArgumentNullException("No revision set for ThunderScope");
+					
+			}
+		}
+	}
 }

--- a/source/TS.NET/Memory/ThunderscopeControlBridgeReader.cs
+++ b/source/TS.NET/Memory/ThunderscopeControlBridgeReader.cs
@@ -6,111 +6,112 @@ using TS.NET.Memory.Windows;
 
 namespace TS.NET
 {
-    // This is a shared memory-mapped file between processes, with only a single writer and a single reader with a header struct
-    public class ThunderscopeControlBridgeReader : IDisposable
-    {
-        private readonly IMemoryFile file;
-        private readonly MemoryMappedViewAccessor view;
-        private unsafe byte* basePointer;
-        private ThunderscopeControlBridgeContent content;
-        private readonly IInterprocessSemaphoreWaiter controlUpdateSemaphore;
+	// This is a shared memory-mapped file between processes, with only a single writer and a single reader with a header struct
+	public class ThunderscopeControlBridgeReader : IDisposable
+	{
+		private readonly IMemoryFile file;
+		private readonly MemoryMappedViewAccessor view;
+		private unsafe byte* basePointer;
+		private ThunderscopeControlBridgeContent content;
+		private readonly IInterprocessSemaphoreWaiter controlUpdateSemaphore;
 
-        public unsafe ThunderscopeControlBridgeReader(string memoryName, ThunderscopeDataBridgeConfig dataBridgeConfig)
-        {
-            memoryName += ".Control";
-            var bridgeCapacityBytes = (ulong)sizeof(ThunderscopeControlBridgeContent);
-            file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? new MemoryFileWindows(memoryName, bridgeCapacityBytes)
-                : new MemoryFileUnix(memoryName, bridgeCapacityBytes);
+		public unsafe ThunderscopeControlBridgeReader(string memoryName, ThunderscopeDataBridgeConfig dataBridgeConfig)
+		{
+			memoryName += ".Control";
+			var bridgeCapacityBytes = (ulong)sizeof(ThunderscopeControlBridgeContent);
+			file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+				? new MemoryFileWindows(memoryName, bridgeCapacityBytes)
+				: new MemoryFileUnix(memoryName, bridgeCapacityBytes);
 
-            try
-            {
-                view = file.MappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite);
+			try
+			{
+				view = file.MappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite);
 
-                try
-                {
-                    basePointer = GetPointer();
-                    // Reader sets initial state of header
-                    content.Version = 1;
-                    content.DataBridge = dataBridgeConfig;
-                    SetHeader();
-                    controlUpdateSemaphore = InterprocessSemaphore.CreateWaiter(memoryName + ".ControlUpdate", 0);
-                }
-                catch
-                {
-                    view.Dispose();
-                    throw;
-                }
-            }
-            catch
-            {
-                file.Dispose();
-                throw;
-            }
+				try
+				{
+					basePointer = GetPointer();
+					// Reader sets initial state of header
+					content.Version = 1;
+					content.DataBridge = dataBridgeConfig;
+					SetHeader();
+					Console.WriteLine("ControlUpdate: " + memoryName + ".ControlUpdate");
+					controlUpdateSemaphore = InterprocessSemaphore.CreateWaiter(memoryName + ".ControlUpdate", 0);
+				}
+				catch
+				{
+					view.Dispose();
+					throw;
+				}
+			}
+			catch
+			{
+				file.Dispose();
+				throw;
+			}
 
 
-        }
+		}
 
-        public void Dispose()
-        {
-            view.SafeMemoryMappedViewHandle.ReleasePointer();
-            view.Flush();
-            view.Dispose();
-            file.Dispose();
-        }
+		public void Dispose()
+		{
+			view.SafeMemoryMappedViewHandle.ReleasePointer();
+			view.Flush();
+			view.Dispose();
+			file.Dispose();
+		}
 
-        public ThunderscopeHardwareConfig Hardware
-        {
-            get
-            {
-                GetHeader();
-                return content.Hardware;
-            }
-        }
+		public ThunderscopeHardwareConfig Hardware
+		{
+			get
+			{
+				GetHeader();
+				return content.Hardware;
+			}
+		}
 
-        public ThunderscopeProcessingConfig Processing
-        {
-            get
-            {
-                GetHeader();
-                return content.Processing;
-            }
-        }
+		public ThunderscopeProcessingConfig Processing
+		{
+			get
+			{
+				GetHeader();
+				return content.Processing;
+			}
+		}
 
-        public bool WaitForUpdate(int millisecondsTimeout, out ThunderscopeHardwareConfig hardware, out ThunderscopeProcessingConfig processing)
-        {
-            var request = controlUpdateSemaphore.Wait(millisecondsTimeout);
-            if (request) while (controlUpdateSemaphore.Wait(0)) { }  // Run down the semaphore in rare edge cases
-            if (request)
-            {
-                GetHeader();
-                hardware = content.Hardware;
-                processing = content.Processing;
-                return true;
-            }
-            hardware = default;
-            processing = default;
-            return false;
-        }
+		public bool WaitForUpdate(int millisecondsTimeout, out ThunderscopeHardwareConfig hardware, out ThunderscopeProcessingConfig processing)
+		{
+			var request = controlUpdateSemaphore.Wait(millisecondsTimeout);
+			if (request) while (controlUpdateSemaphore.Wait(0)) { }  // Run down the semaphore in rare edge cases
+			if (request)
+			{
+				GetHeader();
+				hardware = content.Hardware;
+				processing = content.Processing;
+				return true;
+			}
+			hardware = default;
+			processing = default;
+			return false;
+		}
 
-        private void GetHeader()
-        {
-            unsafe { Unsafe.Copy(ref content, basePointer); }
-        }
+		private void GetHeader()
+		{
+			unsafe { Unsafe.Copy(ref content, basePointer); }
+		}
 
-        private void SetHeader()
-        {
-            unsafe { Unsafe.Copy(basePointer, ref content); }
-        }
+		private void SetHeader()
+		{
+			unsafe { Unsafe.Copy(basePointer, ref content); }
+		}
 
-        private unsafe byte* GetPointer()
-        {
-            byte* ptr = null;
-            view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-            if (ptr == null)
-                throw new InvalidOperationException("Failed to acquire a pointer to the memory mapped file view.");
+		private unsafe byte* GetPointer()
+		{
+			byte* ptr = null;
+			view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+			if (ptr == null)
+				throw new InvalidOperationException("Failed to acquire a pointer to the memory mapped file view.");
 
-            return ptr;
-        }
-    }
+			return ptr;
+		}
+	}
 }

--- a/source/TS.NET/Memory/ThunderscopeDataBridgeWriter.cs
+++ b/source/TS.NET/Memory/ThunderscopeDataBridgeWriter.cs
@@ -6,164 +6,165 @@ using TS.NET.Memory.Windows;
 
 namespace TS.NET
 {
-    // This is a shared memory-mapped file between processes, with only a single writer and a single reader with a header struct
-    // Not thread safe
-    public class ThunderscopeDataBridgeWriter : IDisposable
-    {
-        private readonly IMemoryFile file;
-        private readonly MemoryMappedViewAccessor view;
-        private unsafe byte* basePointer;
-        private unsafe byte* dataPointer { get; }
-        private ThunderscopeDataBridgeHeader header;
-        private readonly IInterprocessSemaphoreWaiter dataRequestSemaphore;         // When this is signalled, a consumer (UI or intermediary) has requested data.
-        private readonly IInterprocessSemaphoreReleaser dataResponseSemaphore;      // When data has been gathered, this is signalled to the consumer to indicate they can consume data.
-        private bool firstRun = true;           // Data bridge writer will always write an initial waveform, to unblock a UI that was running before Engine was started
-        private bool dataRequested = false;
-        private bool acquiringRegionFilledAndWaitingForReader = false;
-        private readonly uint cachedDataWidth;
+	// This is a shared memory-mapped file between processes, with only a single writer and a single reader with a header struct
+	// Not thread safe
+	public class ThunderscopeDataBridgeWriter : IDisposable
+	{
+		private readonly IMemoryFile file;
+		private readonly MemoryMappedViewAccessor view;
+		private unsafe byte* basePointer;
+		private unsafe byte* dataPointer { get; }
+		private ThunderscopeDataBridgeHeader header;
+		private readonly IInterprocessSemaphoreWaiter dataRequestSemaphore;         // When this is signalled, a consumer (UI or intermediary) has requested data.
+		private readonly IInterprocessSemaphoreReleaser dataResponseSemaphore;      // When data has been gathered, this is signalled to the consumer to indicate they can consume data.
+		private bool firstRun = true;           // Data bridge writer will always write an initial waveform, to unblock a UI that was running before Engine was started
+		private bool dataRequested = false;
+		private bool acquiringRegionFilledAndWaitingForReader = false;
+		private readonly uint cachedDataWidth;
 
-        public Span<sbyte> AcquiringRegionI8 { get { return GetAcquiringRegionI8(); } }
-        public ThunderscopeDataMonitoring Monitoring { get { return header.Monitoring; } }
+		public Span<sbyte> AcquiringRegionI8 { get { return GetAcquiringRegionI8(); } }
+		public ThunderscopeDataMonitoring Monitoring { get { return header.Monitoring; } }
 
-        public unsafe ThunderscopeDataBridgeWriter(string memoryName, ThunderscopeDataBridgeConfig bridgeConfig)
-        {
-            memoryName += ".Data";
-            cachedDataWidth = bridgeConfig.ChannelDataType.Width();
-            var dataCapacityBytes = bridgeConfig.MaxChannelCount * bridgeConfig.MaxChannelDataLength * cachedDataWidth * 2;   // * 2 as there are 2 regions used in tick-tock fashion
-            var bridgeCapacityBytes = (ulong)sizeof(ThunderscopeDataBridgeHeader) + dataCapacityBytes;
-            //Console.WriteLine($"Bridge capacity: {bridgeCapacityBytes} bytes");
-            file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? new MemoryFileWindows(memoryName, bridgeCapacityBytes)
-                : new MemoryFileUnix(memoryName, bridgeCapacityBytes);
+		public unsafe ThunderscopeDataBridgeWriter(string memoryName, ThunderscopeDataBridgeConfig bridgeConfig)
+		{
+			memoryName += ".Data";
+			cachedDataWidth = bridgeConfig.ChannelDataType.Width();
+			var dataCapacityBytes = bridgeConfig.MaxChannelCount * bridgeConfig.MaxChannelDataLength * cachedDataWidth * 2;   // * 2 as there are 2 regions used in tick-tock fashion
+			var bridgeCapacityBytes = (ulong)sizeof(ThunderscopeDataBridgeHeader) + dataCapacityBytes;
+			//Console.WriteLine($"Bridge capacity: {bridgeCapacityBytes} bytes");
+			file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+				? new MemoryFileWindows(memoryName, bridgeCapacityBytes)
+				: new MemoryFileUnix(memoryName, bridgeCapacityBytes);
 
-            try
-            {
-                view = file.MappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite);
+			try
+			{
+				view = file.MappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite);
 
-                try
-                {
-                    basePointer = GetPointer();
-                    dataPointer = basePointer + sizeof(ThunderscopeDataBridgeHeader);
+				try
+				{
+					basePointer = GetPointer();
+					dataPointer = basePointer + sizeof(ThunderscopeDataBridgeHeader);
 
-                    // Writer sets initial state of header
-                    header.Version = 1;
-                    header.DataCapacityBytes = dataCapacityBytes;
+					// Writer sets initial state of header
+					header.Version = 1;
+					header.DataCapacityBytes = dataCapacityBytes;
 
-                    header.Bridge = bridgeConfig;                  
+					header.Bridge = bridgeConfig;                  
 
-                    header.AcquiringRegion = ThunderscopeMemoryAcquiringRegion.RegionA;
+					header.AcquiringRegion = ThunderscopeMemoryAcquiringRegion.RegionA;
+					Console.WriteLine("memoryName:" + memoryName);
 
-                    SetHeader();
+					SetHeader();
 
-                    dataRequestSemaphore = InterprocessSemaphore.CreateWaiter(memoryName + ".DataRequest", 0);
-                    dataResponseSemaphore = InterprocessSemaphore.CreateReleaser(memoryName + ".DataResponse", 0);
-                }
-                catch
-                {
-                    view.Dispose();
-                    throw;
-                }
-            }
-            catch
-            {
-                file.Dispose();
-                throw;
-            }
-        }
+					dataRequestSemaphore = InterprocessSemaphore.CreateWaiter(memoryName + ".DataRequest", 0);
+					dataResponseSemaphore = InterprocessSemaphore.CreateReleaser(memoryName + ".DataResponse", 0);
+				}
+				catch
+				{
+					view.Dispose();
+					throw;
+				}
+			}
+			catch
+			{
+				file.Dispose();
+				throw;
+			}
+		}
 
-        public void Dispose()
-        {
-            view.SafeMemoryMappedViewHandle.ReleasePointer();
-            view.Flush();
-            view.Dispose();
-            file.Dispose();
-        }
+		public void Dispose()
+		{
+			view.SafeMemoryMappedViewHandle.ReleasePointer();
+			view.Flush();
+			view.Dispose();
+			file.Dispose();
+		}
 
-        public ThunderscopeHardwareConfig Hardware
-        {
-            set
-            {
-                // This is a shallow copy, but considering the struct should be 100% blitable (i.e. no reference types), this is effectively a full copy
-                header.Hardware = value;
-                SetHeader();
-            }
-        }
+		public ThunderscopeHardwareConfig Hardware
+		{
+			set
+			{
+				// This is a shallow copy, but considering the struct should be 100% blitable (i.e. no reference types), this is effectively a full copy
+				header.Hardware = value;
+				SetHeader();
+			}
+		}
 
-        public ThunderscopeProcessingConfig Processing
-        {
-            set
-            {
-                // This is a shallow copy, but considering the struct should be 100% blitable (i.e. no reference types), this is effectively a full copy
-                header.Processing = value;
-                SetHeader();
-            }
-        }
+		public ThunderscopeProcessingConfig Processing
+		{
+			set
+			{
+				// This is a shallow copy, but considering the struct should be 100% blitable (i.e. no reference types), this is effectively a full copy
+				header.Processing = value;
+				SetHeader();
+			}
+		}
 
-        public void MonitoringReset()
-        {
-            header.Monitoring.TotalAcquisitions = 0;
-            header.Monitoring.DroppedAcquisitions = 0;
-            SetHeader();
-        }
+		public void MonitoringReset()
+		{
+			header.Monitoring.TotalAcquisitions = 0;
+			header.Monitoring.DroppedAcquisitions = 0;
+			SetHeader();
+		}
 
-        public void SwitchRegionIfNeeded()
-        {
-            if (!dataRequested)
-                dataRequested = dataRequestSemaphore.Wait(0);           // Only wait on the semaphore once and cache the result if true, clearing when needed later
-            if ((firstRun || dataRequested) && acquiringRegionFilledAndWaitingForReader)   // UI has requested data and there is data available to be read...
-            {
-                firstRun = false;
-                dataRequested = false;
-                acquiringRegionFilledAndWaitingForReader = false;
-                header.AcquiringRegion = header.AcquiringRegion switch
-                {
-                    ThunderscopeMemoryAcquiringRegion.RegionA => ThunderscopeMemoryAcquiringRegion.RegionB,
-                    ThunderscopeMemoryAcquiringRegion.RegionB => ThunderscopeMemoryAcquiringRegion.RegionA,
-                    _ => throw new InvalidDataException("Enum value not handled, add enum value to switch")
-                };
-                SetHeader();
-                dataResponseSemaphore.Release();        // Allow UI to use the acquired region
-            }
-        }
+		public void SwitchRegionIfNeeded()
+		{
+			if (!dataRequested)
+				dataRequested = dataRequestSemaphore.Wait(0);           // Only wait on the semaphore once and cache the result if true, clearing when needed later
+			if ((firstRun || dataRequested) && acquiringRegionFilledAndWaitingForReader)   // UI has requested data and there is data available to be read...
+			{
+				firstRun = false;
+				dataRequested = false;
+				acquiringRegionFilledAndWaitingForReader = false;
+				header.AcquiringRegion = header.AcquiringRegion switch
+				{
+					ThunderscopeMemoryAcquiringRegion.RegionA => ThunderscopeMemoryAcquiringRegion.RegionB,
+					ThunderscopeMemoryAcquiringRegion.RegionB => ThunderscopeMemoryAcquiringRegion.RegionA,
+					_ => throw new InvalidDataException("Enum value not handled, add enum value to switch")
+				};
+				SetHeader();
+				dataResponseSemaphore.Release();        // Allow UI to use the acquired region
+			}
+		}
 
-        public void DataWritten()
-        {
-            header.Monitoring.TotalAcquisitions++;
-            if (acquiringRegionFilledAndWaitingForReader)
-                header.Monitoring.DroppedAcquisitions++;
-            acquiringRegionFilledAndWaitingForReader = true;
-            SetHeader();
-        }
+		public void DataWritten()
+		{
+			header.Monitoring.TotalAcquisitions++;
+			if (acquiringRegionFilledAndWaitingForReader)
+				header.Monitoring.DroppedAcquisitions++;
+			acquiringRegionFilledAndWaitingForReader = true;
+			SetHeader();
+		}
 
-        //private void GetHeader()
-        //{
-        //    unsafe { Unsafe.Copy(ref header, basePointer); }
-        //}
+		//private void GetHeader()
+		//{
+		//    unsafe { Unsafe.Copy(ref header, basePointer); }
+		//}
 
-        private void SetHeader()
-        {
-            unsafe { Unsafe.Copy(basePointer, ref header); }
-        }
+		private void SetHeader()
+		{
+			unsafe { Unsafe.Copy(basePointer, ref header); }
+		}
 
-        private unsafe byte* GetPointer()
-        {
-            byte* ptr = null;
-            view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-            if (ptr == null)
-                throw new InvalidOperationException("Failed to acquire a pointer to the memory mapped file view.");
+		private unsafe byte* GetPointer()
+		{
+			byte* ptr = null;
+			view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+			if (ptr == null)
+				throw new InvalidOperationException("Failed to acquire a pointer to the memory mapped file view.");
 
-            return ptr;
-        }
+			return ptr;
+		}
 
-        private unsafe Span<sbyte> GetAcquiringRegionI8()
-        {
-            int regionLength = (int)(header.Processing.CurrentChannelCount * header.Processing.CurrentChannelDataLength * cachedDataWidth);
-            return header.AcquiringRegion switch
-            {
-                ThunderscopeMemoryAcquiringRegion.RegionA => new Span<sbyte>(dataPointer, regionLength),
-                ThunderscopeMemoryAcquiringRegion.RegionB => new Span<sbyte>(dataPointer + regionLength, regionLength),
-                _ => throw new InvalidDataException("Enum value not handled, add enum value to switch")
-            };
-        }
-    }
+		private unsafe Span<sbyte> GetAcquiringRegionI8()
+		{
+			int regionLength = (int)(header.Processing.CurrentChannelCount * header.Processing.CurrentChannelDataLength * cachedDataWidth);
+			return header.AcquiringRegion switch
+			{
+				ThunderscopeMemoryAcquiringRegion.RegionA => new Span<sbyte>(dataPointer, regionLength),
+				ThunderscopeMemoryAcquiringRegion.RegionB => new Span<sbyte>(dataPointer + regionLength, regionLength),
+				_ => throw new InvalidDataException("Enum value not handled, add enum value to switch")
+			};
+		}
+	}
 }


### PR DESCRIPTION
This PR enables commandline arguments, specifically -i to select one of mulitple ThunderScopes on a host (Windows only atm, due to XDMA device detection not being implemented under Linux yet), -cport and -dport to set custom listener ports for the control and data plane servers, and -rev to select the PLL configuration dynamically instead of using build time preprocessor directives to switch between them.
