### PR TITLE
Add calibration handling for LiteX driver and library

### DIFF
--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -119,8 +119,14 @@ class Program
             case "litex":
                 {
                     var ts = new TS.NET.Driver.LiteX.Thunderscope(loggerFactory);
-                    ts.Open(0);
-                    // ts.Open(0, thunderscopeSettings.Calibration); //TODO
+
+                    var tsCal = new ThunderscopeChannelCalibrationArray();
+                    tsCal[0] = thunderscopeSettings.Calibration.Channel1.ToDriver();
+                    tsCal[1] = thunderscopeSettings.Calibration.Channel2.ToDriver();
+                    tsCal[2] = thunderscopeSettings.Calibration.Channel3.ToDriver();
+                    tsCal[3] = thunderscopeSettings.Calibration.Channel4.ToDriver();
+
+                    ts.Open((uint)deviceIndex, tsCal);
                     thunderscope = ts;
                     break;
                 }

--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -108,10 +108,10 @@ class Program
                     initialHardwareConfiguration.Frontend[1] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[2] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[3] = ThunderscopeChannelFrontend.Default();
-                    initialHardwareConfiguration.Calibration[0] = thunderscopeSettings.Calibration.Channel1.ToDriver();
-                    initialHardwareConfiguration.Calibration[1] = thunderscopeSettings.Calibration.Channel2.ToDriver();
-                    initialHardwareConfiguration.Calibration[2] = thunderscopeSettings.Calibration.Channel3.ToDriver();
-                    initialHardwareConfiguration.Calibration[3] = thunderscopeSettings.Calibration.Channel4.ToDriver();
+                    initialHardwareConfiguration.Calibration[0] = thunderscopeSettings.XdmaCalibration.Channel1.ToDriver();
+                    initialHardwareConfiguration.Calibration[1] = thunderscopeSettings.XdmaCalibration.Channel2.ToDriver();
+                    initialHardwareConfiguration.Calibration[2] = thunderscopeSettings.XdmaCalibration.Channel3.ToDriver();
+                    initialHardwareConfiguration.Calibration[3] = thunderscopeSettings.XdmaCalibration.Channel4.ToDriver();
                     ts.Open(devices[deviceIndex], initialHardwareConfiguration, thunderscopeSettings.HardwareRevision);
                     thunderscope = ts;
                     break;
@@ -121,10 +121,10 @@ class Program
                     var ts = new TS.NET.Driver.LiteX.Thunderscope(loggerFactory);
 
                     var tsCal = new ThunderscopeChannelCalibrationArray();
-                    tsCal[0] = thunderscopeSettings.Calibration.Channel1.ToDriver();
-                    tsCal[1] = thunderscopeSettings.Calibration.Channel2.ToDriver();
-                    tsCal[2] = thunderscopeSettings.Calibration.Channel3.ToDriver();
-                    tsCal[3] = thunderscopeSettings.Calibration.Channel4.ToDriver();
+                    tsCal[0] = thunderscopeSettings.LiteXCalibration.Channel1.ToDriver();
+                    tsCal[1] = thunderscopeSettings.LiteXCalibration.Channel2.ToDriver();
+                    tsCal[2] = thunderscopeSettings.LiteXCalibration.Channel3.ToDriver();
+                    tsCal[3] = thunderscopeSettings.LiteXCalibration.Channel4.ToDriver();
 
                     ts.Open((uint)deviceIndex, tsCal);
                     thunderscope = ts;

--- a/source/TS.NET.Engine/Settings/ThunderscopeCalibrationSettings.cs
+++ b/source/TS.NET.Engine/Settings/ThunderscopeCalibrationSettings.cs
@@ -45,6 +45,14 @@ namespace TS.NET
         public double PgaOutputAmpGain { get; set; }
         public double HardwareOffsetVoltageLowGain { get; set; }
         public double HardwareOffsetVoltageHighGain { get; set; }
+        public double BufferOffset { get; set; }
+        public double BiasVoltage { get; set; }
+        public double TrimResistorOhms { get; set; }
+        public double PgaLowGainError { get; set; }
+        public double PgaHighGainError { get; set; }
+        public double PgaLowOffsetVoltage { get; set; }
+        public double PgaHighOffsetVoltage { get; set; }
+        public double PgaOutputGainError { get; set; }
 
         public ThunderscopeChannelCalibration ToDriver()
         {
@@ -68,7 +76,15 @@ namespace TS.NET
                 PgaAttenuatorGain10 = this.PgaAttenuatorGain10,
                 PgaOutputAmpGain = this.PgaOutputAmpGain,
                 HardwareOffsetVoltageLowGain = this.HardwareOffsetVoltageLowGain,
-                HardwareOffsetVoltageHighGain = this.HardwareOffsetVoltageHighGain
+                HardwareOffsetVoltageHighGain = this.HardwareOffsetVoltageHighGain,
+                BufferOffset = this.BufferOffset,
+                BiasVoltage = this.BiasVoltage,
+                TrimResistorOhms = this.TrimResistorOhms,
+                PgaLowGainError = this.PgaLowGainError,
+                PgaHighGainError = this.PgaHighGainError,
+                PgaLowOffsetVoltage = this.PgaLowOffsetVoltage,
+                PgaHighOffsetVoltage = this.PgaHighOffsetVoltage,
+                PgaOutputGainError = this.PgaOutputGainError
             };
         }
 
@@ -94,7 +110,15 @@ namespace TS.NET
                 PgaAttenuatorGain10 = -20,
                 PgaOutputAmpGain = 8.86,
                 HardwareOffsetVoltageLowGain = 2.525,
-                HardwareOffsetVoltageHighGain = 2.525
+                HardwareOffsetVoltageHighGain = 2.525,
+                BufferOffset = 2.5,
+                BiasVoltage = 2.5,
+                TrimResistorOhms = 50000,
+                PgaLowGainError = 0,
+                PgaHighGainError = 0,
+                PgaLowOffsetVoltage = 0,
+                PgaHighOffsetVoltage = 0,
+                PgaOutputGainError = 0
             };
         }
     }

--- a/source/TS.NET.Engine/Settings/ThunderscopeCalibrationSettings.cs
+++ b/source/TS.NET.Engine/Settings/ThunderscopeCalibrationSettings.cs
@@ -53,6 +53,7 @@ namespace TS.NET
         public double PgaLowOffsetVoltage { get; set; }
         public double PgaHighOffsetVoltage { get; set; }
         public double PgaOutputGainError { get; set; }
+        public double PgaInputBiasCurrent { get; set; }
 
         public ThunderscopeChannelCalibration ToDriver()
         {
@@ -84,7 +85,8 @@ namespace TS.NET
                 PgaHighGainError = this.PgaHighGainError,
                 PgaLowOffsetVoltage = this.PgaLowOffsetVoltage,
                 PgaHighOffsetVoltage = this.PgaHighOffsetVoltage,
-                PgaOutputGainError = this.PgaOutputGainError
+                PgaOutputGainError = this.PgaOutputGainError,
+                PgaInputBiasCurrent = this.PgaInputBiasCurrent
             };
         }
 
@@ -118,7 +120,8 @@ namespace TS.NET
                 PgaHighGainError = 0,
                 PgaLowOffsetVoltage = 0,
                 PgaHighOffsetVoltage = 0,
-                PgaOutputGainError = 0
+                PgaOutputGainError = 0,
+                PgaInputBiasCurrent = 40
             };
         }
     }

--- a/source/TS.NET.Engine/Settings/ThunderscopeSettings.cs
+++ b/source/TS.NET.Engine/Settings/ThunderscopeSettings.cs
@@ -19,7 +19,8 @@ namespace TS.NET.Engine
         public int HardwareThreadProcessorAffinity { get; set; }
         public int ProcessingThreadProcessorAffinity { get; set; }
 
-        public ThunderscopeCalibrationSettings Calibration { get; set; }
+        public ThunderscopeCalibrationSettings XdmaCalibration { get; set; }
+        public ThunderscopeCalibrationSettings LiteXCalibration { get; set; }
 
         public static ThunderscopeSettings Default()
         {
@@ -36,7 +37,8 @@ namespace TS.NET.Engine
                 HardwareThreadProcessorAffinity = -1,
                 ProcessingThreadProcessorAffinity = -1,
 
-                Calibration = ThunderscopeCalibrationSettings.Default()
+                XdmaCalibration = ThunderscopeCalibrationSettings.Default(),
+                LiteXCalibration = ThunderscopeCalibrationSettings.Default()
             };
         }
 

--- a/source/TS.NET.Engine/thunderscope.yaml
+++ b/source/TS.NET.Engine/thunderscope.yaml
@@ -89,6 +89,7 @@ Calibration:
     PgaLowOffsetVoltage: 0
     PgaHighOffsetVoltage: 0
     PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
   Channel2:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -117,6 +118,7 @@ Calibration:
     PgaLowOffsetVoltage: 0
     PgaHighOffsetVoltage: 0
     PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
   Channel3:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -145,6 +147,7 @@ Calibration:
     PgaLowOffsetVoltage: 0
     PgaHighOffsetVoltage: 0
     PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
   Channel4:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -173,3 +176,4 @@ Calibration:
     PgaLowOffsetVoltage: 0
     PgaHighOffsetVoltage: 0
     PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40

--- a/source/TS.NET.Engine/thunderscope.yaml
+++ b/source/TS.NET.Engine/thunderscope.yaml
@@ -60,7 +60,7 @@ ProcessingThreadProcessorAffinity: -1
 # Value: Double, nominally 0.02 with slight variation based on calibration.
 # Sets the multiplier for the frontend relay-switched attenuator.
 
-Calibration:
+XdmaCalibration:
   Channel1:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -81,15 +81,6 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.529
     HardwareOffsetVoltageHighGain: 2.533
-    BufferOffset: 2.5
-    BiasVoltage: 2.5
-    TrimResistorOhms: 50000
-    PgaLowGainError: 0
-    PgaHighGainError: 0
-    PgaLowOffsetVoltage: 0
-    PgaHighOffsetVoltage: 0
-    PgaOutputGainError: 0
-    PgaInputBiasCurrent: 40
   Channel2:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -110,15 +101,6 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.521
     HardwareOffsetVoltageHighGain: 2.525
-    BufferOffset: 2.5
-    BiasVoltage: 2.5
-    TrimResistorOhms: 50000
-    PgaLowGainError: 0
-    PgaHighGainError: 0
-    PgaLowOffsetVoltage: 0
-    PgaHighOffsetVoltage: 0
-    PgaOutputGainError: 0
-    PgaInputBiasCurrent: 40
   Channel3:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -139,15 +121,6 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.528
     HardwareOffsetVoltageHighGain: 2.525
-    BufferOffset: 2.5
-    BiasVoltage: 2.5
-    TrimResistorOhms: 50000
-    PgaLowGainError: 0
-    PgaHighGainError: 0
-    PgaLowOffsetVoltage: 0
-    PgaHighOffsetVoltage: 0
-    PgaOutputGainError: 0
-    PgaInputBiasCurrent: 40
   Channel4:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -168,6 +141,51 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.524
     HardwareOffsetVoltageHighGain: 2.525
+
+LiteXCalibration:
+  Channel1:
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
+    BufferGain: -0.25
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
+  Channel2:
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
+    BufferGain: -0.25
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
+  Channel3:
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
+    BufferGain: -0.25
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
+    PgaInputBiasCurrent: 40
+  Channel4:
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
+    BufferGain: -0.25
     BufferOffset: 2.5
     BiasVoltage: 2.5
     TrimResistorOhms: 50000

--- a/source/TS.NET.Engine/thunderscope.yaml
+++ b/source/TS.NET.Engine/thunderscope.yaml
@@ -62,8 +62,8 @@ ProcessingThreadProcessorAffinity: -1
 
 Calibration:
   Channel1:
-    AttenuatorGain1MOhm: -34
-    AttenuatorGain50Ohm: -14
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
     BufferGain: -0.25
     PgaPreampLowGain: 10
     PgaPreampHighGain: 30
@@ -81,9 +81,17 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.529
     HardwareOffsetVoltageHighGain: 2.533
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
   Channel2:
-    AttenuatorGain1MOhm: -34
-    AttenuatorGain50Ohm: -14
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
     BufferGain: -0.25
     PgaPreampLowGain: 10
     PgaPreampHighGain: 30
@@ -101,9 +109,17 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.521
     HardwareOffsetVoltageHighGain: 2.525
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
   Channel3:
-    AttenuatorGain1MOhm: -34
-    AttenuatorGain50Ohm: -14
+    AttenuatorGain1MOhm: -33.9794
+    AttenuatorGain50Ohm: -13.9794
     BufferGain: -0.25
     PgaPreampLowGain: 10
     PgaPreampHighGain: 30
@@ -121,6 +137,14 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.528
     HardwareOffsetVoltageHighGain: 2.525
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0
   Channel4:
     AttenuatorGain1MOhm: -33.9794
     AttenuatorGain50Ohm: -13.9794
@@ -141,3 +165,11 @@ Calibration:
     PgaOutputAmpGain: 8.86
     HardwareOffsetVoltageLowGain: 2.524
     HardwareOffsetVoltageHighGain: 2.525
+    BufferOffset: 2.5
+    BiasVoltage: 2.5
+    TrimResistorOhms: 50000
+    PgaLowGainError: 0
+    PgaHighGainError: 0
+    PgaLowOffsetVoltage: 0
+    PgaHighOffsetVoltage: 0
+    PgaOutputGainError: 0

--- a/source/TS.NET/Drivers/LiteX/Interop/Interop.cs
+++ b/source/TS.NET/Drivers/LiteX/Interop/Interop.cs
@@ -62,6 +62,7 @@ namespace TS.NET.Driver.LiteX
             public int preampOutputGainError_mdB;
             public int preampLowOffset_mV;
             public int preampHighOffset_mV;
+            public int preampInputBias_uA;
         }
 
         [LibraryImport(library, EntryPoint = "thunderscopeOpen")]

--- a/source/TS.NET/Drivers/LiteX/Interop/Interop.cs
+++ b/source/TS.NET/Drivers/LiteX/Interop/Interop.cs
@@ -18,17 +18,17 @@ namespace TS.NET.Driver.LiteX
             public byte reserved;
         }
 
-        // [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        // public struct tsDeviceInfo_t
-        // {
-        //     uint deviceID;
-        //     [MarshalAs (UnmanagedType.ByValTStr, SizeConst=256)]
-        //     string devicePath;
-        //     [MarshalAs (UnmanagedType.ByValTStr, SizeConst=256)]
-        //     string identity;
-        //     [MarshalAs (UnmanagedType.ByValTStr, SizeConst=256)]
-        //     string serialNumber;
-        // }
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        public struct tsDeviceInfo_t
+        {
+            public uint deviceID;
+            // [MarshalAs (UnmanagedType.ByValTStr, SizeConst = 256)]
+            // public string devicePath;
+            // [MarshalAs (UnmanagedType.ByValTStr, SizeConst = 256)]
+            // public string identity;
+            // [MarshalAs (UnmanagedType.ByValTStr, SizeConst = 256)]
+            // public string serialNumber;
+        }
 
         
         [StructLayout(LayoutKind.Sequential)]
@@ -45,29 +45,48 @@ namespace TS.NET.Driver.LiteX
             public uint vcc_bram;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public struct tsChannelCalibration_t
+        {
+            public int buffer_mV;
+            public int bias_mV;
+            public int attenuatorGain1M_mdB;
+            public int attenuatorGain50_mdB;
+            public int bufferGain_mdB;
+            public int trimRheostat_range;
+            public int preampLowGainError_mdB;
+            public int preampHighGainError_mdB;
+
+            // [MarshalAs(UnmanagedType.ByValArray, SizeConst = 11)]
+            // public int[] preampAttenuatorGain_mdB;
+            public int preampOutputGainError_mdB;
+            public int preampLowOffset_mV;
+            public int preampHighOffset_mV;
+        }
+
         [LibraryImport(library, EntryPoint = "thunderscopeOpen")]
         public static partial nint Open(uint devIndex);
 
         [LibraryImport(library, EntryPoint = "thunderscopeClose")]
         public static partial int Close(nint ts);
 
-        // [LibraryImport(library, EntryPoint = "thunderscopeListDevices")]
-        // public static partial int ListDevices(uint devIndex, ref tsDeviceInfo_t devInfo);
+        [LibraryImport(library, EntryPoint = "thunderscopeListDevices", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ListDevices(uint devIndex, out tsDeviceInfo_t devInfo);
 
         [LibraryImport(library, EntryPoint = "thunderscopeChannelConfigGet")]
-        public static partial int GetChannelConfig(nint ts, uint channel, ref tsChannelParam_t conf);
+        public static partial int GetChannelConfig(nint ts, uint channel, out tsChannelParam_t conf);
         
         [LibraryImport(library, EntryPoint = "thunderscopeChannelConfigSet")]
-        public static partial int SetChannelConfig(nint ts, uint channel, ref tsChannelParam_t conf);
+        public static partial int SetChannelConfig(nint ts, uint channel, in tsChannelParam_t conf);
 
         [LibraryImport(library, EntryPoint = "thunderscopeStatusGet")]
-        public static partial int GetStatus(nint ts, ref tsScopeState_t conf);
+        public static partial int GetStatus(nint ts, out tsScopeState_t conf);
 
         [LibraryImport(library, EntryPoint = "thunderscopeSampleModeSet")]
         public static partial int SetSampleMode(nint ts, uint rate, uint resolution);
 
         [LibraryImport(library, EntryPoint = "thunderscopeCalibrationSet")]
-        public static partial int SetCalibration(nint ts, uint channel, uint cal);
+        public static partial int SetCalibration(nint ts, uint channel, in tsChannelCalibration_t cal);
 
         [LibraryImport(library, EntryPoint = "thunderscopeDataEnable")]
         public static partial int DataEnable(nint ts, byte enable);

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Microsoft.Extensions.Logging;
 using TS.NET.Driver.LiteX;
 
@@ -242,6 +242,7 @@ namespace TS.NET.Driver.LiteX
                 preampLowOffset_mV = (int)(channelCalibration.PgaLowOffsetVoltage * 1000),
                 preampHighOffset_mV = (int)(channelCalibration.PgaHighOffsetVoltage * 1000),
                 preampOutputGainError_mdB = (int)(channelCalibration.PgaOutputGainError * 1000),
+                preampInputBias_uA = (int)channelCalibration.PgaInputBiasCurrent,
             };
 
             tsCalibration[channelIndex] = channelCalibration;

--- a/source/TS.NET/Utility/ThunderscopeChannelCalibration.cs
+++ b/source/TS.NET/Utility/ThunderscopeChannelCalibration.cs
@@ -25,5 +25,13 @@ namespace TS.NET
         public double PgaOutputAmpGain { get; set; }
         public double HardwareOffsetVoltageLowGain { get; set; }
         public double HardwareOffsetVoltageHighGain { get; set; }
+        public double BufferOffset { get; set; }
+        public double BiasVoltage { get; set; }
+        public double TrimResistorOhms { get; set; }
+        public double PgaLowGainError { get; set; }
+        public double PgaHighGainError { get; set; }
+        public double PgaLowOffsetVoltage { get; set; }
+        public double PgaHighOffsetVoltage { get; set; }
+        public double PgaOutputGainError { get; set; }
     }
 }

--- a/source/TS.NET/Utility/ThunderscopeChannelCalibration.cs
+++ b/source/TS.NET/Utility/ThunderscopeChannelCalibration.cs
@@ -33,5 +33,6 @@ namespace TS.NET
         public double PgaLowOffsetVoltage { get; set; }
         public double PgaHighOffsetVoltage { get; set; }
         public double PgaOutputGainError { get; set; }
+        public double PgaInputBiasCurrent { get; set; }
     }
 }


### PR DESCRIPTION
Implement Calibration tracking and setting with the LiteX driver.

This adds new calibration parameters used by the LiteX library for calculating gains and offsets:
- BufferOffset
- BiasVoltage
- TrimResistorOhms
- PgaLowGainError
- PgaHighGainError
- PgaLowOffsetVoltage
- PgaHighOffsetVoltage
- PgaOutputGainError
- PgaInputBiasCurrent (uA)